### PR TITLE
use miniaod slimmedJets as input

### DIFF
--- a/Validation/RecoParticleFlow/Makefile
+++ b/Validation/RecoParticleFlow/Makefile
@@ -1,4 +1,4 @@
-TMPDIR=tmp2
+TMPDIR=tmp
 RELVALCMD=${CMSSW_BASE}/src/Validation/RecoParticleFlow/test/run_relval.sh
 
 QCD: QCD_reco QCD_dqm

--- a/Validation/RecoParticleFlow/Makefile
+++ b/Validation/RecoParticleFlow/Makefile
@@ -1,4 +1,4 @@
-TMPDIR=tmp
+TMPDIR=tmp2
 RELVALCMD=${CMSSW_BASE}/src/Validation/RecoParticleFlow/test/run_relval.sh
 
 QCD: QCD_reco QCD_dqm

--- a/Validation/RecoParticleFlow/python/particleFlowDQM_cff.py
+++ b/Validation/RecoParticleFlow/python/particleFlowDQM_cff.py
@@ -41,8 +41,8 @@ def createResponsePlots():
 pfDQMAnalyzer = cms.EDAnalyzer("ParticleFlowDQM",
 
     #match these reco-jets to the gen-jets and compute jet response
-    recoJetCollection = cms.InputTag('ak4PFJets'),
-    genJetCollection = cms.InputTag('ak4GenJets'),
+    recoJetCollection = cms.InputTag('slimmedJets'),
+    genJetCollection = cms.InputTag('slimmedGenJets'),
     jetDeltaR = cms.double(0.2),
 
     responsePlots = cms.VPSet(createResponsePlots())

--- a/Validation/RecoParticleFlow/test/condor_sub.jdl
+++ b/Validation/RecoParticleFlow/test/condor_sub.jdl
@@ -23,8 +23,8 @@ RequestCpus = 1
 run_as_owner = True
 
 #transfer section
-transfer_output_files = QCD/step3.log,QCD/step3.root
-transfer_output_remaps = "step3.log=step3.$(Cluster).$(Process).log;step3.root=step3.$(Cluster).$(Process).root"
+transfer_output_files = QCD/step3.log,QCD/step3_inMINIAODSIM.root
+transfer_output_remaps = "step3.log=step3.$(Cluster).$(Process).log;step3_inMINIAODSIM.root=step3_inMINIAODSIM.$(Cluster).$(Process).root"
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT
 

--- a/Validation/RecoParticleFlow/test/run_relval.sh
+++ b/Validation/RecoParticleFlow/test/run_relval.sh
@@ -97,7 +97,7 @@ if [ $STEP == "RECO" ]; then
     #Run the actual CMS reco with particle flow.
     #On lxplus, this step takes about 15 minutes / 1000 events
     echo "Running step RECO" 
-    cmsDriver.py step3  --customise_commands="process.source.skipEvents=cms.untracked.uint32($SKIPEVENTS)" --runUnscheduled  --conditions $CONDITIONS -s RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT --datatier RECOSIM --nThreads $NTHREADS -n $PERJOB --era $ERA --eventcontent RECOSIM --filein filelist:$INPUT_FILELIST --fileout file:step3.root | tee step3.log  2>&1
+    cmsDriver.py step3  --customise_commands="process.source.skipEvents=cms.untracked.uint32($SKIPEVENTS)" --runUnscheduled  --conditions $CONDITIONS -s RAW2DIGI,L1Reco,RECO,RECOSIM,EI,PAT --datatier RECOSIM,AODSIM,MINIAODSIM --nThreads $NTHREADS -n $PERJOB --era $ERA --eventcontent RECOSIM,AODSIM,MINIAODSIM --filein filelist:$INPUT_FILELIST --fileout file:step3.root | tee step3.log  2>&1
    
     #NanoAOD
     #On lxplus, this step takes about 1 minute / 1000 events
@@ -109,7 +109,7 @@ elif [ $STEP == "DQM" ]; then
     cd $NAME
     
     #get all the filenames and make them into a python-compatible list of strings
-    STEP3FNS=`ls -1 step3*.root | sed 's/^/"file:/;s/$/",/' | tr '\n' ' '`
+    STEP3FNS=`ls -1 step3*MINIAODSIM*.root | sed 's/^/"file:/;s/$/",/' | tr '\n' ' '`
     echo "step3 filenames for DQM: "$STEP3FNS
 
     #Run the DQM sequences (PF DQM only)

--- a/Validation/RecoParticleFlow/test/run_relval.sh
+++ b/Validation/RecoParticleFlow/test/run_relval.sh
@@ -109,12 +109,13 @@ elif [ $STEP == "DQM" ]; then
     cd $NAME
     
     #get all the filenames and make them into a python-compatible list of strings
-    STEP3FNS=`ls -1 step3*MINIAODSIM*.root | sed 's/^/"file:/;s/$/",/' | tr '\n' ' '`
+    #STEP3FNS=`ls -1 step3*MINIAODSIM*.root | sed 's/^/"file:/;s/$/",/' | tr '\n' ' '`
+    ls -1 step3*MINIAODSIM*.root | sed 's/^/file:/' > step3_filelist.txt
     echo "step3 filenames for DQM: "$STEP3FNS
 
     #Run the DQM sequences (PF DQM only)
     #override the filenames here as cmsDriver does not allow multiple input files and there is no easy way to merge EDM files
-    cmsDriver.py step5 --customise_commands="process.source.fileNames=cms.untracked.vstring($STEP3FNS)" --conditions $CONDITIONS -s DQM:@pfDQM --datatier DQMIO --nThreads $NTHREADS --era $ERA --eventcontent DQM --filein DUMMY --fileout file:step5.root -n -1 | tee step5.log 2>&1
+    cmsDriver.py step5 --conditions $CONDITIONS -s DQM:@pfDQM --datatier DQMIO --nThreads $NTHREADS --era $ERA --eventcontent DQM --filein filelist:step3_filelist.txt --fileout file:step5.root -n -1 | tee step5.log 2>&1
 
     #Harvesting converts the histograms stored in TTrees to be stored in folders by run etc
     cmsDriver.py step6 --conditions $CONDITIONS -s HARVESTING:@pfDQM --era $ERA --filetype DQM --filein file:step5.root --fileout file:step6.root | tee step6.log 2>&1


### PR DESCRIPTION
AS discussed in #15, want to run the PF validation on CHS-corrected jets. Therefore, we run the AOD and MINIAOD sequences as well and reconfigure the DQM to run on `slimmedJets`.

I ran on 200 events, the pt-dependent reso plot is here:
[reso_pt.pdf](https://github.com/jpata/cmssw/files/2809506/reso_pt.pdf)
