### PR TITLE
MLPF update in 2025, CMSSW_15_0_1

### DIFF
--- a/CommonTools/PileupAlgos/plugins/MLPFPUProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/MLPFPUProducer.cc
@@ -1,0 +1,488 @@
+#include "CommonTools/PileupAlgos/interface/RecoObj.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/PtEtaPhiMass.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include <memory>
+
+// ------------------------------------------------------------------------------------------
+class MLPFPUProducer : public edm::stream::EDProducer<> {
+public:
+  explicit MLPFPUProducer(const edm::ParameterSet&);
+  ~MLPFPUProducer() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  typedef math::XYZTLorentzVector LorentzVector;
+  typedef std::vector<LorentzVector> LorentzVectorCollection;
+  typedef reco::VertexCollection VertexCollection;
+  typedef edm::View<reco::Candidate> CandidateView;
+  typedef std::vector<reco::PFCandidate> PFInputCollection;
+  typedef std::vector<reco::PFCandidate> PFOutputCollection;
+  typedef std::vector<pat::PackedCandidate> PackedOutputCollection;
+  typedef edm::View<reco::PFCandidate> PFView;
+  typedef edm::Association<reco::VertexCollection> CandToVertex;
+
+private:
+  virtual void beginJob();
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob();
+
+  edm::EDGetTokenT<CandidateView> tokenPFCandidates_;
+  edm::EDGetTokenT<VertexCollection> tokenVertices_;
+  edm::EDGetTokenT<CandToVertex> tokenVertexAssociation_;
+  edm::EDGetTokenT<edm::ValueMap<int>> tokenVertexAssociationQuality_;
+  edm::EDGetTokenT<PFOutputCollection> tokenCandidates_;
+  edm::EDGetTokenT<PackedOutputCollection> tokenPackedCandidates_;
+  edm::EDPutTokenT<edm::ValueMap<float>> ptokenPupOut_;
+  edm::EDPutTokenT<edm::ValueMap<LorentzVector>> ptokenP4PupOut_;
+  edm::EDPutTokenT<edm::ValueMap<reco::CandidatePtr>> ptokenValues_;
+  edm::EDPutTokenT<pat::PackedCandidateCollection> ptokenPackedCandidates_;
+  edm::EDPutTokenT<reco::PFCandidateCollection> ptokenCandidates_;
+  bool fUseVertexAssociation;
+  int vertexAssociationQuality_;
+  bool fUseFromPVLooseTight;
+  bool fUseFromPV2Recovery;
+  bool fUseDZ;
+  bool fUseDZforPileup;
+  double fDZCut;
+  double fEtaMinUseDZ;
+  double fPtMaxCharged;
+  double fEtaMaxCharged;
+  double fPtMaxPhotons;
+  double fEtaMaxPhotons;
+  double fPtMinForFromPV2Recovery;
+  uint fNumOfPUVtxsForCharged;
+  double fDZCutForChargedFromPUVtxs;
+  bool fUseExistingWeights;
+  bool fApplyPhotonProtectionForExistingWeights;
+  bool fClonePackedCands;
+  int fVtxNdofCut;
+  double fVtxZCut;
+  double fMLPFPUCut;
+  std::vector<RecoObj> fRecoObjCollection;
+};
+
+// ------------------------------------------------------------------------------------------
+MLPFPUProducer::MLPFPUProducer(const edm::ParameterSet& iConfig) {
+  fUseFromPVLooseTight = iConfig.getParameter<bool>("UseFromPVLooseTight");
+  fUseFromPV2Recovery = iConfig.getParameter<bool>("UseFromPV2Recovery");
+  fUseDZ = iConfig.getParameter<bool>("UseDeltaZCut");
+  fUseDZforPileup = iConfig.getParameter<bool>("UseDeltaZCutForPileup");
+  fDZCut = iConfig.getParameter<double>("DeltaZCut");
+  fEtaMinUseDZ = iConfig.getParameter<double>("EtaMinUseDeltaZ");
+  fPtMaxCharged = iConfig.getParameter<double>("PtMaxCharged");
+  fEtaMaxCharged = iConfig.getParameter<double>("EtaMaxCharged");
+  fPtMaxPhotons = iConfig.getParameter<double>("PtMaxPhotons");
+  fEtaMaxPhotons = iConfig.getParameter<double>("EtaMaxPhotons");
+  fPtMinForFromPV2Recovery = iConfig.getParameter<double>("PtMinForFromPV2Recovery");
+  fNumOfPUVtxsForCharged = iConfig.getParameter<uint>("NumOfPUVtxsForCharged");
+  fDZCutForChargedFromPUVtxs = iConfig.getParameter<double>("DeltaZCutForChargedFromPUVtxs");
+  fUseExistingWeights = iConfig.getParameter<bool>("useExistingWeights");
+  fApplyPhotonProtectionForExistingWeights = iConfig.getParameter<bool>("applyPhotonProtectionForExistingWeights");
+  fClonePackedCands = iConfig.getParameter<bool>("clonePackedCands");
+  fVtxNdofCut = iConfig.getParameter<int>("vtxNdofCut");
+  fVtxZCut = iConfig.getParameter<double>("vtxZCut");
+  fMLPFPUCut = iConfig.getParameter<double>("mlpfPUCut");
+
+  tokenPFCandidates_ = consumes<CandidateView>(iConfig.getParameter<edm::InputTag>("candName"));
+  tokenVertices_ = consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexName"));
+  fUseVertexAssociation = iConfig.getParameter<bool>("useVertexAssociation");
+  vertexAssociationQuality_ = iConfig.getParameter<int>("vertexAssociationQuality");
+  if (fUseVertexAssociation) {
+    tokenVertexAssociation_ = consumes<CandToVertex>(iConfig.getParameter<edm::InputTag>("vertexAssociation"));
+    tokenVertexAssociationQuality_ =
+        consumes<edm::ValueMap<int>>(iConfig.getParameter<edm::InputTag>("vertexAssociation"));
+  }
+
+  ptokenPupOut_ = produces<edm::ValueMap<float>>();
+  ptokenP4PupOut_ = produces<edm::ValueMap<LorentzVector>>();
+  ptokenValues_ = produces<edm::ValueMap<reco::CandidatePtr>>();
+
+  if (fUseExistingWeights || fClonePackedCands)
+    ptokenPackedCandidates_ = produces<pat::PackedCandidateCollection>();
+  else {
+    ptokenCandidates_ = produces<reco::PFCandidateCollection>();
+  }
+
+}
+// ------------------------------------------------------------------------------------------
+MLPFPUProducer::~MLPFPUProducer() {}
+// ------------------------------------------------------------------------------------------
+void MLPFPUProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // Get PFCandidate Collection
+  edm::Handle<CandidateView> hPFProduct;
+  iEvent.getByToken(tokenPFCandidates_, hPFProduct);
+  const CandidateView* pfCol = hPFProduct.product();
+
+  // Get vertex collection w/PV as the first entry?
+  edm::Handle<reco::VertexCollection> hVertexProduct;
+  iEvent.getByToken(tokenVertices_, hVertexProduct);
+  const reco::VertexCollection* pvCol = hVertexProduct.product();
+
+  edm::Association<reco::VertexCollection> associatedPV;
+  edm::ValueMap<int> associationQuality;
+  if ((fUseVertexAssociation) && (!fUseExistingWeights)) {
+    associatedPV = iEvent.get(tokenVertexAssociation_);
+    associationQuality = iEvent.get(tokenVertexAssociationQuality_);
+  }
+
+  std::vector<double> lWeights;
+  if (!fUseExistingWeights) {
+    //Fill the reco objects
+    fRecoObjCollection.clear();
+    fRecoObjCollection.reserve(pfCol->size());
+    int iCand = 0;
+    for (auto const& aPF : *pfCol) {
+      RecoObj pReco;
+      pReco.pt = aPF.pt();
+      pReco.eta = aPF.eta();
+      pReco.phi = aPF.phi();
+      pReco.m = aPF.mass();
+      pReco.rapidity = aPF.rapidity();
+      pReco.charge = aPF.charge();
+      pReco.pdgId = aPF.pdgId();
+      const reco::Vertex* closestVtx = nullptr;
+      double pDZ = -9999;
+      double pD0 = -9999;
+      uint pVtxId = 0;
+      const pat::PackedCandidate* lPack = dynamic_cast<const pat::PackedCandidate*>(&aPF);
+
+      if (fUseVertexAssociation) {
+        const reco::VertexRef& PVOrig = associatedPV[reco::CandidatePtr(hPFProduct, iCand)];
+        int quality = associationQuality[reco::CandidatePtr(hPFProduct, iCand)];
+        if (PVOrig.isNonnull() && (quality >= vertexAssociationQuality_)) {
+          closestVtx = PVOrig.get();
+          pVtxId = PVOrig.key();
+        }
+        if (std::abs(pReco.charge) == 0)
+          pReco.id = 0;
+        else if (closestVtx != nullptr && pVtxId == 0)
+          pReco.id = 1;  // Associated to main vertex
+        else if (closestVtx != nullptr && pVtxId > 0)
+          pReco.id = 2;  // Associated to PU
+        else
+          pReco.id = 0;  // Unassociated
+      } else if (lPack == nullptr) {
+        const reco::PFCandidate* pPF = dynamic_cast<const reco::PFCandidate*>(&aPF);
+        double curdz = 9999;
+        int closestVtxForUnassociateds = -9999;
+        const reco::TrackRef aTrackRef = pPF->trackRef();
+        bool lFirst = true;
+        for (auto const& aV : *pvCol) {
+          if (lFirst) {
+            if (aTrackRef.isNonnull()) {
+              pDZ = aTrackRef->dz(aV.position());
+              pD0 = aTrackRef->d0();
+            } else if (pPF->gsfTrackRef().isNonnull()) {
+              pDZ = pPF->gsfTrackRef()->dz(aV.position());
+              pD0 = pPF->gsfTrackRef()->d0();
+            }
+            lFirst = false;
+            if (pDZ > -9999)
+              pVtxId = 0;
+          }
+          if (aTrackRef.isNonnull() && aV.trackWeight(pPF->trackRef()) > 0) {
+            closestVtx = &aV;
+            break;
+          }
+          // in case it's unassocciated, keep more info
+          double tmpdz = 99999;
+          if (aTrackRef.isNonnull())
+            tmpdz = aTrackRef->dz(aV.position());
+          else if (pPF->gsfTrackRef().isNonnull())
+            tmpdz = pPF->gsfTrackRef()->dz(aV.position());
+          if (std::abs(tmpdz) < curdz) {
+            curdz = std::abs(tmpdz);
+            closestVtxForUnassociateds = pVtxId;
+          }
+          pVtxId++;
+        }
+        int tmpFromPV = 0;
+        // mocking the miniAOD definitions
+        if (std::abs(pReco.charge) > 0) {
+          if (closestVtx != nullptr && pVtxId > 0)
+            tmpFromPV = 0;
+          if (closestVtx != nullptr && pVtxId == 0)
+            tmpFromPV = 3;
+          if (closestVtx == nullptr && closestVtxForUnassociateds == 0)
+            tmpFromPV = 2;
+          if (closestVtx == nullptr && closestVtxForUnassociateds != 0)
+            tmpFromPV = 1;
+        }
+        pReco.dZ = pDZ;
+        pReco.d0 = pD0;
+	//id definition:
+	//0 : particles not handled by CHS
+	//1 : PV particles as identified by CHS
+	//2: PU particles as identified by CHS
+        pReco.id = 0;
+        if (std::abs(pReco.charge) == 0) {
+          pReco.id = 0;
+        } else {
+          if (tmpFromPV == 0) {
+            pReco.id = 2;
+            if (fNumOfPUVtxsForCharged > 0 and (pVtxId <= fNumOfPUVtxsForCharged) and
+                (std::abs(pDZ) < fDZCutForChargedFromPUVtxs))
+              pReco.id = 1;
+          } else if (tmpFromPV == 3)
+            pReco.id = 1;
+          else if (tmpFromPV == 1 || tmpFromPV == 2) {
+            pReco.id = 0;
+            if ((fPtMaxCharged > 0) and (pReco.pt > fPtMaxCharged))
+              pReco.id = 1;
+            else if (std::abs(pReco.eta) > fEtaMaxCharged)
+              pReco.id = 1;
+            else if ((fUseDZ) && (std::abs(pReco.eta) >= fEtaMinUseDZ) && (std::abs(pDZ) < fDZCut))
+              pReco.id = 1;
+            else if (fUseFromPV2Recovery && tmpFromPV == 2 && (pReco.pt > fPtMinForFromPV2Recovery))
+              pReco.id = 1;
+            else if ((fUseDZforPileup) && (std::abs(pReco.eta) >= fEtaMinUseDZ) && (std::abs(pDZ) >= fDZCut))
+              pReco.id = 2;
+            else if (fUseFromPVLooseTight && tmpFromPV == 1)
+              pReco.id = 2;
+            else if (fUseFromPVLooseTight && tmpFromPV == 2)
+              pReco.id = 1;
+          }
+        }
+        // if undecided by CHS, use MLPF prediction
+        if (pReco.id==0) {
+	      pReco.id = pPF->mlpf_pu() < fMLPFPUCut? 1:2;
+	}
+      } else if (lPack->vertexRef().isNonnull()) {
+        pDZ = lPack->dz();
+        pD0 = lPack->dxy();
+        pReco.dZ = pDZ;
+        pReco.d0 = pD0;
+
+        pReco.id = 0;
+        if (std::abs(pReco.charge) == 0) {
+          pReco.id = 0;
+        }
+        if (std::abs(pReco.charge) > 0) {
+          if (lPack->fromPV() == 0) {
+            pReco.id = 2;
+            if ((fNumOfPUVtxsForCharged > 0) and (std::abs(pDZ) < fDZCutForChargedFromPUVtxs)) {
+              for (size_t puVtx_idx = 1; puVtx_idx <= fNumOfPUVtxsForCharged && puVtx_idx < pvCol->size();
+                   ++puVtx_idx) {
+                if (lPack->fromPV(puVtx_idx) >= 2) {
+                  pReco.id = 1;
+                  break;
+                }
+              }
+            }
+          } else if (lPack->fromPV() == (pat::PackedCandidate::PVUsedInFit)) {
+            pReco.id = 1;
+          } else if (lPack->fromPV() == (pat::PackedCandidate::PVTight) ||
+                     lPack->fromPV() == (pat::PackedCandidate::PVLoose)) {
+            pReco.id = 0;
+            if ((fPtMaxCharged > 0) and (pReco.pt > fPtMaxCharged))
+              pReco.id = 1;
+            else if (std::abs(pReco.eta) > fEtaMaxCharged)
+              pReco.id = 1;
+            else if ((fUseDZ) && (std::abs(pReco.eta) >= fEtaMinUseDZ) && (std::abs(pDZ) < fDZCut))
+              pReco.id = 1;
+            else if (fUseFromPV2Recovery && lPack->fromPV() == (pat::PackedCandidate::PVTight) &&
+                     (pReco.pt > fPtMinForFromPV2Recovery))
+              pReco.id = 1;
+            else if ((fUseDZforPileup) && (std::abs(pReco.eta) >= fEtaMinUseDZ) && (std::abs(pDZ) >= fDZCut))
+              pReco.id = 2;
+            else if (fUseFromPVLooseTight && lPack->fromPV() == (pat::PackedCandidate::PVLoose))
+              pReco.id = 2;
+            else if (fUseFromPVLooseTight && lPack->fromPV() == (pat::PackedCandidate::PVTight))
+              pReco.id = 1;
+          }
+        }
+      }
+
+      fRecoObjCollection.push_back(pReco);
+      iCand++;
+    }
+    //Fill weights
+    lWeights.clear();
+    lWeights.reserve(iCand);
+
+    for (int i0 = 0; i0 < iCand; i0++) {
+      const auto rParticle = fRecoObjCollection[i0];
+
+      // Apply PUPPI CHS and MLPF Prediction
+      if (rParticle.id == 1)
+        lWeights.push_back(1);
+      else
+        lWeights.push_back(0);
+    }
+  } else {  
+    //Use the existing weights
+    lWeights.reserve(pfCol->size());
+    for (auto const& aPF : *pfCol) {
+      const pat::PackedCandidate* lPack = dynamic_cast<const pat::PackedCandidate*>(&aPF);
+      float curpupweight = -1.;
+      if (lPack == nullptr) {
+        // throw error
+        throw edm::Exception(edm::errors::LogicError,
+                             "PuppiProducer: cannot get weights since inputs are not PackedCandidates");
+      } else {
+          curpupweight = lPack->puppiWeight();
+      }
+      // Optional: Protect high pT photons (important for gamma to hadronic recoil balance) for existing weights.
+      if (fApplyPhotonProtectionForExistingWeights && (fPtMaxPhotons > 0) && (lPack->pdgId() == 22) &&
+          (std::abs(lPack->eta()) < fEtaMaxPhotons) && (lPack->pt() > fPtMaxPhotons))
+        curpupweight = 1;
+      lWeights.push_back(curpupweight);
+    }
+  }
+
+  //Fill it into the event
+  edm::ValueMap<float> lPupOut;
+  edm::ValueMap<float>::Filler lPupFiller(lPupOut);
+  lPupFiller.insert(hPFProduct, lWeights.begin(), lWeights.end());
+  lPupFiller.fill();
+
+  // This is a dummy to access the "translate" method which is a
+  // non-static member function even though it doesn't need to be.
+  // Will fix in the future.
+  static const reco::PFCandidate dummySinceTranslateIsNotStatic;
+
+  // Fill a new PF/Packed Candidate Collection and write out the ValueMap of the new p4s.
+  // Since the size of the ValueMap must be equal to the input collection, we need
+  // to search the "puppi" particles to find a match for each input. If none is found,
+  // the input is set to have a four-vector of 0,0,0,0
+  PFOutputCollection fCandidates;
+  PackedOutputCollection fPackedCandidates;
+
+  edm::ValueMap<LorentzVector> p4PupOut;
+  LorentzVectorCollection puppiP4s;
+  std::vector<reco::CandidatePtr> values(hPFProduct->size());
+
+  int iCand = -1;
+  puppiP4s.reserve(hPFProduct->size());
+  if (fUseExistingWeights || fClonePackedCands)
+    fPackedCandidates.reserve(hPFProduct->size());
+  else
+    fCandidates.reserve(hPFProduct->size());
+  for (auto const& aCand : *hPFProduct) {
+    ++iCand;
+    std::unique_ptr<pat::PackedCandidate> pCand;
+    std::unique_ptr<reco::PFCandidate> pfCand;
+
+    if (fUseExistingWeights || fClonePackedCands) {
+      const pat::PackedCandidate* cand = dynamic_cast<const pat::PackedCandidate*>(&aCand);
+      if (!cand)
+        throw edm::Exception(edm::errors::LogicError, "MLPFPUProducer: inputs are not PackedCandidates");
+      pCand = std::make_unique<pat::PackedCandidate>(*cand);
+    } else {
+      auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(aCand.pdgId());
+      const reco::PFCandidate* cand = dynamic_cast<const reco::PFCandidate*>(&aCand);
+      pfCand = std::make_unique<reco::PFCandidate>(cand ? *cand : reco::PFCandidate(aCand.charge(), aCand.p4(), id));
+    }
+
+    // Here, we are using new weights computed and putting them in the packed candidates.
+    if (fClonePackedCands && (!fUseExistingWeights)) {
+      pCand->setPuppiWeight(lWeights[iCand], pCand->puppiWeightNoLep());
+    }
+
+    puppiP4s.emplace_back(lWeights[iCand] * aCand.px(),
+                          lWeights[iCand] * aCand.py(),
+                          lWeights[iCand] * aCand.pz(),
+                          lWeights[iCand] * aCand.energy());
+
+    if (fUseExistingWeights || fClonePackedCands) {
+      pCand->setP4(puppiP4s.back());
+      pCand->setSourceCandidatePtr(aCand.sourceCandidatePtr(0));
+      fPackedCandidates.push_back(*pCand);
+    } else {
+      pfCand->setP4(puppiP4s.back());
+      pfCand->setSourceCandidatePtr(aCand.sourceCandidatePtr(0));
+      fCandidates.push_back(*pfCand);
+    }
+  }
+
+  //Compute the modified p4s
+  edm::ValueMap<LorentzVector>::Filler p4PupFiller(p4PupOut);
+  p4PupFiller.insert(hPFProduct, puppiP4s.begin(), puppiP4s.end());
+  p4PupFiller.fill();
+
+  iEvent.emplace(ptokenPupOut_, lPupOut);
+  iEvent.emplace(ptokenP4PupOut_, p4PupOut);
+  if (fUseExistingWeights || fClonePackedCands) {
+    edm::OrphanHandle<pat::PackedCandidateCollection> oh =
+        iEvent.emplace(ptokenPackedCandidates_, fPackedCandidates);
+    for (unsigned int ic = 0, nc = oh->size(); ic < nc; ++ic) {
+      reco::CandidatePtr pkref(oh, ic);
+      values[ic] = pkref;
+    }
+  } else {
+    edm::OrphanHandle<reco::PFCandidateCollection> oh = iEvent.emplace(ptokenCandidates_, fCandidates);
+    for (unsigned int ic = 0, nc = oh->size(); ic < nc; ++ic) {
+      reco::CandidatePtr pkref(oh, ic);
+      values[ic] = pkref;
+    }
+  }
+  edm::ValueMap<reco::CandidatePtr> pfMap_p;
+  edm::ValueMap<reco::CandidatePtr>::Filler filler(pfMap_p);
+  filler.insert(hPFProduct, values.begin(), values.end());
+  filler.fill();
+  iEvent.emplace(ptokenValues_, pfMap_p);
+
+}
+
+// ------------------------------------------------------------------------------------------
+void MLPFPUProducer::beginJob() {}
+// ------------------------------------------------------------------------------------------
+void MLPFPUProducer::endJob() {}
+// ------------------------------------------------------------------------------------------
+void MLPFPUProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("puppiDiagnostics", false);
+  desc.add<bool>("puppiNoLep", false);
+  desc.add<bool>("UseFromPVLooseTight", false);
+  desc.add<bool>("UseFromPV2Recovery", false);
+  desc.add<bool>("UseDeltaZCut", true);
+  desc.add<bool>("UseDeltaZCutForPileup", true);
+  desc.add<double>("DeltaZCut", 0.3);
+  desc.add<double>("EtaMinUseDeltaZ", 0.);
+  desc.add<double>("PtMaxCharged", -1.);
+  desc.add<double>("EtaMaxCharged", 99999.);
+  desc.add<double>("PtMaxPhotons", -1.);
+  desc.add<double>("EtaMaxPhotons", 2.5);
+  desc.add<double>("PtMaxNeutrals", 200.);
+  desc.add<double>("PtMaxNeutralsStartSlope", 0.);
+  desc.add<double>("PtMinForFromPV2Recovery", 0.);
+  desc.add<uint>("NumOfPUVtxsForCharged", 0);
+  desc.add<double>("DeltaZCutForChargedFromPUVtxs", 0.2);
+  desc.add<bool>("useExistingWeights", false);
+  desc.add<bool>("applyPhotonProtectionForExistingWeights", false);
+  desc.add<bool>("clonePackedCands", false);
+  desc.add<int>("vtxNdofCut", 4);
+  desc.add<double>("vtxZCut", 24);
+  desc.add<edm::InputTag>("candName", edm::InputTag("particleFlow"));
+  desc.add<edm::InputTag>("vertexName", edm::InputTag("offlinePrimaryVertices"));
+  desc.add<bool>("useVertexAssociation", false);
+  desc.add<int>("vertexAssociationQuality", 0);
+  desc.add<edm::InputTag>("vertexAssociation", edm::InputTag(""));
+  desc.add<bool>("applyCHS", true);
+  desc.add<bool>("invertPuppi", false);
+  desc.add<bool>("useExp", false);
+  desc.add<double>("MinPuppiWeight", .01);
+  desc.add<bool>("usePUProxyValue", false);
+  desc.add<double>("mlpfPUCut", 0.5);
+  desc.add<edm::InputTag>("PUProxyValue", edm::InputTag(""));
+
+  descriptions.add("MLPFPUProducer", desc);
+}
+//define this as a plug-in
+DEFINE_FWK_MODULE(MLPFPUProducer);

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -71,6 +71,22 @@ puppi.algos.append(cms.PSet(
                        #   puppiAlgos = puppiForward
                        # )
 
+from Configuration.ProcessModifiers.mlpf_cff import mlpf
+from CommonTools.PileupAlgos.MLPFPUProducer_cfi import MLPFPUProducer
+mlpfpu = MLPFPUProducer.clone(
+                      UseDeltaZCutForPileup = False,
+                      DeltaZCut = primaryVertexAssociationJME.assignment.maxDzForPrimaryAssignment,
+                      EtaMinUseDeltaZ = primaryVertexAssociationJME.assignment.EtaMinUseDz,
+                      PtMaxCharged = primaryVertexAssociationJME.assignment.PtMaxCharged,
+                      NumOfPUVtxsForCharged = primaryVertexAssociationJME.assignment.NumOfPUVtxsForCharged,
+                      DeltaZCutForChargedFromPUVtxs = primaryVertexAssociationJME.assignment.DzCutForChargedFromPUVtxs,
+                      PtMaxPhotons = 20.,
+                      UseFromPV2Recovery = True,
+                      PtMinForFromPV2Recovery = 4.,
+                      clonePackedCands   = False, # should only be set to True for MiniAOD
+)
+mlpf.toReplaceWith(puppi, mlpfpu)
+
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(
     puppi,

--- a/Configuration/Generator/python/MultiParticlePFGun50_cfi.py
+++ b/Configuration/Generator/python/MultiParticlePFGun50_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDProducer("FlatEtaRangeGunProducer",
+    PGunParameters = cms.PSet(
+        PartID = cms.vint32([11, -11, 13, -13, 15, -15, 211, -211, 22, 130, -130, 111, -111]),
+        MinEta = cms.double(-4.5),
+        MaxEta = cms.double(4.5),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinE = cms.double(1.0),
+        MaxE = cms.double(1000.0),
+        nParticles = cms.int32(50),
+        exactShoot = cms.bool(False),
+        randomShoot = cms.bool(True),
+    ),
+    AddAntiParticle = cms.bool(False),
+    debug=cms.untracked.bool(True),
+)

--- a/Configuration/Generator/python/MultiParticlePFGun50_cfi.py
+++ b/Configuration/Generator/python/MultiParticlePFGun50_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 generator = cms.EDProducer("FlatEtaRangeGunProducer",
     PGunParameters = cms.PSet(
-        PartID = cms.vint32([11, -11, 13, -13, 211, -211, 22, 130, -130, 111, -111]),
+        PartID = cms.vint32([11, -11, 13, -13, 211, -211, 22, 130, -130]),
         MinEta = cms.double(-5),
         MaxEta = cms.double(5),
         MinPhi = cms.double(-3.14159265359),

--- a/Configuration/Generator/python/MultiParticlePFGun50_cfi.py
+++ b/Configuration/Generator/python/MultiParticlePFGun50_cfi.py
@@ -2,9 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 generator = cms.EDProducer("FlatEtaRangeGunProducer",
     PGunParameters = cms.PSet(
-        PartID = cms.vint32([11, -11, 13, -13, 15, -15, 211, -211, 22, 130, -130, 111, -111]),
-        MinEta = cms.double(-4.5),
-        MaxEta = cms.double(4.5),
+        PartID = cms.vint32([11, -11, 13, -13, 211, -211, 22, 130, -130, 111, -111]),
+        MinEta = cms.double(-5),
+        MaxEta = cms.double(5),
         MinPhi = cms.double(-3.14159265359),
         MaxPhi = cms.double(3.14159265359),
         MinE = cms.double(1.0),

--- a/Configuration/Generator/python/SingleElectronFlatPt1To1000_pythia8_cfi.py
+++ b/Configuration/Generator/python/SingleElectronFlatPt1To1000_pythia8_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        MaxPt = cms.double(1000.),
+        MinPt = cms.double(1.),
+        ParticleID = cms.vint32(11),
+        AddAntiParticle = cms.bool(False),
+        MaxEta = cms.double(4.5),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-4.5),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single electron pt 1 to 1000'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )
+

--- a/Configuration/Generator/python/SingleGammaFlatPt1To1000_pythia8_cfi.py
+++ b/Configuration/Generator/python/SingleGammaFlatPt1To1000_pythia8_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        MaxPt = cms.double(1000.),
+        MinPt = cms.double(1.),
+        ParticleID = cms.vint32(22),
+        AddAntiParticle = cms.bool(False), # false in pythia6 version but photons are their own anti-particle
+        MaxEta = cms.double(4.5),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-4.5),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single gamma pt 1 to 1000'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SingleK0FlatPt1To1000_pythia8_cfi.py
+++ b/Configuration/Generator/python/SingleK0FlatPt1To1000_pythia8_cfi.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        MaxPt = cms.double(1000.),
+        MinPt = cms.double(1.),
+        ParticleID = cms.vint32(130),
+        AddAntiParticle = cms.bool(False), # false in pythia6 version but photons are their own anti-particle
+        MaxEta = cms.double(4.5),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-4.5),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single k0 pt 1 to 1000'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SingleMuFlatPt1To1000_pythia8_cfi.py
+++ b/Configuration/Generator/python/SingleMuFlatPt1To1000_pythia8_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        MaxPt = cms.double(1000.0),
+        MinPt = cms.double(1),
+        ParticleID = cms.vint32(-13),
+        AddAntiParticle = cms.bool(True),
+        MaxEta = cms.double(3.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-3.0),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single mu pt 1 to 1000'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SingleMuPlusFlatPt0p7To1000_cfi.py
+++ b/Configuration/Generator/python/SingleMuPlusFlatPt0p7To1000_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        MaxPt = cms.double(1000.0),
+        MinPt = cms.double(0.7),
+        ParticleID = cms.vint32(-13),
+        AddAntiParticle = cms.bool(False),
+        MaxEta = cms.double(3.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-3.0),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single muminus pt 0.7 to 1000'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SingleNeutronFlatPt0p7To1000_cfi.py
+++ b/Configuration/Generator/python/SingleNeutronFlatPt0p7To1000_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        MaxPt = cms.double(1000.0),
+        MinPt = cms.double(0.7),
+        ParticleID = cms.vint32(2112),
+        AddAntiParticle = cms.bool(False),
+        MaxEta = cms.double(5.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-5.0),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single neutron pt 0.7 to 1000'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SinglePi0Pt1To1000_pythia8_cfi.py
+++ b/Configuration/Generator/python/SinglePi0Pt1To1000_pythia8_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        ParticleID = cms.vint32(111),
+        AddAntiParticle = cms.bool(False),
+        MaxEta = cms.double(4.5),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-4.5),
+        MinPt = cms.double(1),
+        MinPhi = cms.double(-3.14159265359), ## in radians
+        MaxPt = cms.double(1000.0)
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single pi0 E 10'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SinglePiMinusFlatPt0p7To1000_cfi.py
+++ b/Configuration/Generator/python/SinglePiMinusFlatPt0p7To1000_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        MaxPt = cms.double(1000.0),
+        MinPt = cms.double(0.7),
+        ParticleID = cms.vint32(-211),
+        AddAntiParticle = cms.bool(False),
+        MaxEta = cms.double(5.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-5.0),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single piminus pt 0.7 to 1000'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SinglePiPlusFlatPt0p7To1000_cfi.py
+++ b/Configuration/Generator/python/SinglePiPlusFlatPt0p7To1000_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        MaxPt = cms.double(1000.0),
+        MinPt = cms.double(0.7),
+        ParticleID = cms.vint32(211),
+        AddAntiParticle = cms.bool(False),
+        MaxEta = cms.double(5.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-5.0),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single piplus pt 0.7 to 1000'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SingleProtonMinusFlatPt0p7To1000_cfi.py
+++ b/Configuration/Generator/python/SingleProtonMinusFlatPt0p7To1000_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        MaxPt = cms.double(1000.0),
+        MinPt = cms.double(0.7),
+        ParticleID = cms.vint32(-2212),
+        AddAntiParticle = cms.bool(False),
+        MaxEta = cms.double(5.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-5.0),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single protonminus pt 0.7 to 1000'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SingleProtonPlusFlatPt0p7To1000_cfi.py
+++ b/Configuration/Generator/python/SingleProtonPlusFlatPt0p7To1000_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         PGunParameters = cms.PSet(
+        MaxPt = cms.double(1000.0),
+        MinPt = cms.double(0.7),
+        ParticleID = cms.vint32(2212),
+        AddAntiParticle = cms.bool(False),
+        MaxEta = cms.double(5.0),
+        MaxPhi = cms.double(3.14159265359),
+        MinEta = cms.double(-5.0),
+        MinPhi = cms.double(-3.14159265359) ## in radians
+        ),
+                         Verbosity = cms.untracked.int32(0), ## set to 1 (or greater)  for printouts
+                         psethack = cms.string('single protonplus pt 0.7 to 1000'),
+                         firstRun = cms.untracked.uint32(1),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SingleTauFlatPt1To1000_cfi.py
+++ b/Configuration/Generator/python/SingleTauFlatPt1To1000_cfi.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         pythia8CommonSettingsBlock,
+                         PGunParameters = cms.PSet(
+        ParticleID = cms.vint32(-15),
+        AddAntiParticle = cms.bool(False),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinPt = cms.double(1.0),
+        MaxPt = cms.double(1000.000),
+        MinEta = cms.double(-4.5),
+        MaxEta = cms.double(4.5)
+        ),
+                         pythiaTauJets = cms.vstring(
+        'ParticleDecays:sophisticatedTau = 2',
+        'ParticleDecays:tauPolarization = 0',
+        "15:onMode = off",
+        "15:onIfAny = 211 -211 321 -321" # turn on if there is a charged k or pi in the decay products 
+        ),
+                         parameterSets = cms.vstring(
+        'pythia8CommonSettings',
+        'pythiaTauJets'
+        ),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SingleTauMinusFlatPt1To1000_cfi.py
+++ b/Configuration/Generator/python/SingleTauMinusFlatPt1To1000_cfi.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         pythia8CommonSettingsBlock,
+                         PGunParameters = cms.PSet(
+        ParticleID = cms.vint32(-15),
+        AddAntiParticle = cms.bool(False),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinPt = cms.double(2.0),
+        MaxPt = cms.double(1000.000),
+        MinEta = cms.double(-5.0),
+        MaxEta = cms.double(5.0)
+        ),
+                         pythiaTauJets = cms.vstring(
+        'ParticleDecays:sophisticatedTau = 2',
+        'ParticleDecays:tauPolarization = 0',
+        "15:onMode = off",
+        "15:onIfAny = 211 -211 321 -321" # turn on if there is a charged k or pi in the decay products 
+        ),
+                         parameterSets = cms.vstring(
+        'pythia8CommonSettings',
+        'pythiaTauJets'
+        ),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/SingleTauPlusFlatPt1To1000_cfi.py
+++ b/Configuration/Generator/python/SingleTauPlusFlatPt1To1000_cfi.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8PtGun",
+                         pythia8CommonSettingsBlock,
+                         PGunParameters = cms.PSet(
+        ParticleID = cms.vint32(15),
+        AddAntiParticle = cms.bool(False),
+        MinPhi = cms.double(-3.14159265359),
+        MaxPhi = cms.double(3.14159265359),
+        MinPt = cms.double(2.0),
+        MaxPt = cms.double(1000.000),
+        MinEta = cms.double(-5.0),
+        MaxEta = cms.double(5.0)
+        ),
+                         pythiaTauJets = cms.vstring(
+        'ParticleDecays:sophisticatedTau = 2',
+        'ParticleDecays:tauPolarization = 0',
+        "15:onMode = off",
+        "15:onIfAny = 211 -211 321 -321" # turn on if there is a charged k or pi in the decay products 
+        ),
+                         parameterSets = cms.vstring(
+        'pythia8CommonSettings',
+        'pythiaTauJets'
+        ),
+                         PythiaParameters = cms.PSet(parameterSets = cms.vstring())
+                         )

--- a/Configuration/Generator/python/VBF_TuneCP5_14TeV_pythia8_cfi.py
+++ b/Configuration/Generator/python/VBF_TuneCP5_14TeV_pythia8_cfi.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.MCTunes2017.PythiaCP5Settings_cfi import *
+
+generator = cms.EDFilter("Pythia8ConcurrentGeneratorFilter",
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(14000.0),
+                         maxEventsToPrint = cms.untracked.int32(0),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         crossSection = cms.untracked.double(0.004783), # 4.233 pb * 0.00113 (qqH * BR(4v))
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CP5SettingsBlock,
+        processParameters = cms.vstring(
+            'HiggsSM:ff2Hff(t:ZZ) = on',
+            'HiggsSM:ff2Hff(t:WW) = on',
+            '25:m0 = 125',
+            ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CP5Settings',
+                                    'processParameters',
+                                    )
+        )
+                         )

--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -122,6 +122,7 @@ addMixingScenario("2018_25ns_ProjectedPileup_PoissonOOTPU",{'file': 'SimGeneral.
 addMixingScenario("2018_25ns_JuneProjectionFull18_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2018_25ns_JuneProjectionFull18_PoissonOOTPU_cfi'})
 addMixingScenario("2018_25ns_UltraLegacy_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2018_25ns_UltraLegacy_PoissonOOTPU_cfi'})
 addMixingScenario("Run3_Flat55To75_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_Run3_Flat55To75_PoissonOOTPU_cfi'})
+addMixingScenario("Run3_Flat0To150_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_Run3_Flat0To150_PoissonOOTPU_cfi'})
 addMixingScenario("Flat0To200_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_Flat0To200_PoissonOOTPU_cfi'})
 addMixingScenario("2022_25ns_RunIII2022Summer24_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2022_25ns_RunIII2022Summer24_PoissonOOTPU_cfi'})
 addMixingScenario("2023_Fills_8807_8901_ProjectedPileup_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2023_Fills_8807_8901_ProjectedPileup_PoissonOOTPU_cfi'})

--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -368,6 +368,10 @@ namespace reco {
     float dnn_gamma() const { return dnn_gamma_; }
     void set_dnn_gamma(float mva) { dnn_gamma_ = mva; }
 
+    // set MLPF PU prediction
+    float mlpf_pu() const { return mlpf_pu_; }
+    void set_mlpf_pu(float mva) { mlpf_pu_ = mva; }
+
     /// mva for neutral hadron - gamma discrimination
     float mva_gamma_nh() const { return mva_gamma_nh_; }
 
@@ -534,6 +538,9 @@ namespace reco {
 
     // DNN for gamma PFid
     float dnn_gamma_;
+
+    // MLPF PU prediction
+    float mlpf_pu_;
 
     /// position at ECAL entrance, from the PFRecTrack
     math::XYZPointF positionAtECALEntrance_;

--- a/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
+++ b/DataFormats/ParticleFlowCandidate/src/PFCandidate.cc
@@ -46,6 +46,7 @@ PFCandidate::PFCandidate()
       dnn_e_bkgTau_(PFCandidate::bigMva_),
       dnn_e_bkgPhoton_(PFCandidate::bigMva_),
       dnn_gamma_(PFCandidate::bigMva_),
+      mlpf_pu_(PFCandidate::bigMva_),
       getter_(nullptr),
       storedRefsBitPattern_(0),
       time_(0.f),
@@ -91,6 +92,7 @@ PFCandidate::PFCandidate(Charge charge, const LorentzVector& p4, ParticleType pa
       dnn_e_bkgTau_(PFCandidate::bigMva_),
       dnn_e_bkgPhoton_(PFCandidate::bigMva_),
       dnn_gamma_(PFCandidate::bigMva_),
+      mlpf_pu_(PFCandidate::bigMva_),
       getter_(nullptr),
       storedRefsBitPattern_(0),
       time_(0.f),
@@ -153,6 +155,7 @@ PFCandidate::PFCandidate(PFCandidate const& iOther)
       dnn_e_bkgTau_(iOther.dnn_e_bkgTau_),
       dnn_e_bkgPhoton_(iOther.dnn_e_bkgPhoton_),
       dnn_gamma_(iOther.dnn_gamma_),
+      mlpf_pu_(iOther.mlpf_pu_),
       positionAtECALEntrance_(iOther.positionAtECALEntrance_),
       getter_(iOther.getter_),
       storedRefsBitPattern_(iOther.storedRefsBitPattern_),
@@ -203,6 +206,7 @@ PFCandidate& PFCandidate::operator=(PFCandidate const& iOther) {
   dnn_e_bkgTau_ = iOther.dnn_e_bkgTau_;
   dnn_e_bkgPhoton_ = iOther.dnn_e_bkgPhoton_;
   dnn_gamma_ = iOther.dnn_gamma_;
+  mlpf_pu_ = iOther.mlpf_pu_;
   positionAtECALEntrance_ = iOther.positionAtECALEntrance_;
   getter_ = iOther.getter_;
   storedRefsBitPattern_ = iOther.storedRefsBitPattern_;

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
-   <class name="reco::PFCandidate" ClassVersion="20">
+   <class name="reco::PFCandidate" ClassVersion="21">
+    <version ClassVersion="21" checksum="886233478"/>
     <version ClassVersion="20" checksum="2748489940"/>
     <version ClassVersion="19" checksum="2990582232"/>
     <version ClassVersion="18" checksum="910857761"/>
@@ -54,7 +55,8 @@
   <class name="edm::PtrVector<reco::PFCandidate> "/>
   <class name="edm::Wrapper<edm::PtrVector<reco::PFCandidate> >"/>
 
-  <class name="reco::IsolatedPFCandidate"  ClassVersion="16">
+  <class name="reco::IsolatedPFCandidate"  ClassVersion="17">
+   <version ClassVersion="17" checksum="3495855271"/>
    <version ClassVersion="16" checksum="2274533749"/>
    <version ClassVersion="15" checksum="3042264953"/>
    <version ClassVersion="14" checksum="207328514"/>
@@ -70,7 +72,8 @@
   <class name="reco::IsolatedPFCandidateRefVector"/>
   <class name="reco::IsolatedPFCandidatePtr"/>
 
-  <class name="reco::PileUpPFCandidate"  ClassVersion="16">
+  <class name="reco::PileUpPFCandidate"  ClassVersion="17">
+   <version ClassVersion="17" checksum="2302317004"/>
    <version ClassVersion="16" checksum="3331568330"/>
    <version ClassVersion="15" checksum="953549166"/>
    <version ClassVersion="14" checksum="4065938015"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -310,7 +310,8 @@
    <version ClassVersion="11" checksum="3492108938"/>
    <version ClassVersion="10" checksum="417284221"/>
   </class>
-  <class name="pat::PFParticle"  ClassVersion="16">
+  <class name="pat::PFParticle"  ClassVersion="17">
+   <version ClassVersion="17" checksum="3216247286"/>
    <version ClassVersion="16" checksum="4057492004"/>
    <version ClassVersion="15" checksum="1485536104"/>
    <version ClassVersion="14" checksum="2795911745"/>

--- a/IOMC/ParticleGuns/interface/FlatEtaRangeGunProducer.h
+++ b/IOMC/ParticleGuns/interface/FlatEtaRangeGunProducer.h
@@ -1,0 +1,46 @@
+/*
+ * Particle gun that can be positioned in space given ranges in rho, z and phi.
+ */
+
+#ifndef IOMC_PARTICLEGUN_FlatEtaRangeGunProducer_H
+#define IOMC_PARTICLEGUN_FlatEtaRangeGunProducer_H
+
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+
+#include "IOMC/ParticleGuns/interface/FlatRandomEGunProducer.h"
+#include "HepMC/GenEvent.h"
+#include "HepPDT/ParticleDataTable.hh"
+
+namespace edm {
+
+  class FlatEtaRangeGunProducer : public FlatRandomEGunProducer {
+  public:
+    FlatEtaRangeGunProducer(const ParameterSet&);
+
+  private:
+    void produce(Event&, const EventSetup&) override;
+
+  protected:
+    // the number of particles to shoot
+    int nParticles_;
+
+    // flag that denotes that exactly the particles defined by fPartIds should be shot, with that order and quantity
+    bool exactShoot_;
+
+    // flag that denotes whether a random number of particles in the range [1, fNParticles] is shot
+    bool randomShoot_;
+
+    const std::vector<double> discreteEnergies_;
+
+    double minDr_;
+
+    // debug flag
+    bool debug_;
+  };
+
+}  // namespace edm
+
+#endif  // IOMC_PARTICLEGUN_FlatEtaRangeGunProducer_H

--- a/IOMC/ParticleGuns/interface/FlatRandomEGunProducer.h
+++ b/IOMC/ParticleGuns/interface/FlatRandomEGunProducer.h
@@ -18,7 +18,7 @@ namespace edm {
 
     void produce(Event& e, const EventSetup& es) override;
 
-  private:
+  protected:
     // data members
 
     double fMinE;

--- a/IOMC/ParticleGuns/src/FlatEtaRangeGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatEtaRangeGunProducer.cc
@@ -1,0 +1,137 @@
+#include <ostream>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+
+#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+
+#include "DataFormats/Math/interface/Vector3D.h"
+
+#include "IOMC/ParticleGuns/interface/FlatEtaRangeGunProducer.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
+edm::FlatEtaRangeGunProducer::FlatEtaRangeGunProducer(const edm::ParameterSet& params)
+    : FlatRandomEGunProducer(params),
+      nParticles_(params.getParameter<ParameterSet>("PGunParameters").getParameter<int>("nParticles")),
+      exactShoot_(params.getParameter<ParameterSet>("PGunParameters").getParameter<bool>("exactShoot")),
+      randomShoot_(params.getParameter<ParameterSet>("PGunParameters").getParameter<bool>("randomShoot")),
+      minDr_(params.getParameter<ParameterSet>("PGunParameters").getUntrackedParameter<double>("minDr", -1.)),
+      debug_(params.getUntrackedParameter<bool>("debug")) {
+}
+
+void edm::FlatEtaRangeGunProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
+  edm::Service<edm::RandomNumberGenerator> rng;
+  CLHEP::HepRandomEngine* engine = &(rng->getEngine(event.streamID()));
+
+  if (debug_) {
+    LogDebug("FlatEtaRangeGunProducer") << " : Begin New Event Generation" << std::endl;
+  }
+
+  // create a new event to fill
+  auto* genEvent = new HepMC::GenEvent();
+
+  // determine the number of particles to shoot
+  int n = 0;
+  if (exactShoot_) {
+    n = (int)fPartIDs.size();
+    std::cout << "exactShoot n=" << nParticles_ << std::endl;
+  } else if (randomShoot_) {
+    n = CLHEP::RandFlat::shoot(engine, 1, nParticles_ + 1);
+    std::cout << "randomShoot n=" << nParticles_ << std::endl;
+  } else {
+    n = nParticles_;
+    std::cout << "else n=" << nParticles_ << std::endl;
+  }
+
+  std::vector<math::XYZVector > previousp4;
+  int particle_counter = 0;
+  // shoot particles
+  for (int i = 0; i < 2 * n; i++) {  //n for positive and n for negative eta
+    // create a random deltaR
+
+    // obtain kinematics
+    int id = fPartIDs[exactShoot_ ? particle_counter : CLHEP::RandFlat::shoot(engine, 0, fPartIDs.size())];
+    std::cout << "generating id=" << id << std::endl;
+    particle_counter++;
+    if (particle_counter >= n)
+      particle_counter = 0;
+
+    const HepPDT::ParticleData* pData = fPDGTable->particle(HepPDT::ParticleID(abs(id)));
+    double eta = CLHEP::RandFlat::shoot(engine, fMinEta, fMaxEta);
+    if (i < n)
+      eta *= -1;
+    double phi = CLHEP::RandFlat::shoot(engine, fMinPhi, fMaxPhi);
+
+
+
+    double e = CLHEP::RandFlat::shoot(engine, fMinE, fMaxE);
+    double m = pData->mass().value();
+    double p = sqrt(e * e - m * m);
+    math::XYZVector pVec = p * math::XYZVector(cos(phi), sin(phi), sinh(eta)).unit();
+
+
+    //check
+    if(minDr_>0){
+        bool isgood=true;
+        for(const auto ppvec: previousp4){
+            double drsq = reco::deltaR2(pVec,ppvec);
+            if(drsq<minDr_){
+                isgood=false;
+                break;
+            }
+        }
+        if(!isgood)
+            continue;
+    }
+
+    previousp4.push_back(pVec);
+
+    HepMC::GenVertex* vtx = new HepMC::GenVertex(HepMC::FourVector(0, 0, 0, 0));
+
+    // create the GenParticle
+    HepMC::FourVector fVec(pVec.x(), pVec.y(), pVec.z(), e);
+    HepMC::GenParticle* particle = new HepMC::GenParticle(fVec, id, 1);
+    particle->suggest_barcode(i + 1);
+
+    // add the particle to the vertex and the vertex to the event
+    vtx->add_particle_out(particle);
+    genEvent->add_vertex(vtx);
+
+    if (debug_) {
+      vtx->print();
+      particle->print();
+    }
+  }
+
+  // fill event attributes
+  genEvent->set_event_number(event.id().event());
+  genEvent->set_signal_process_id(20);
+
+  if (debug_) {
+    genEvent->print();
+  }
+
+  // store outputs
+  std::unique_ptr<HepMCProduct> BProduct(new HepMCProduct());
+  BProduct->addHepMCData(genEvent);
+  event.put(std::move(BProduct), "unsmeared");
+  auto genEventInfo = std::make_unique<GenEventInfoProduct>(genEvent);
+  event.put(std::move(genEventInfo));
+
+  if (debug_) {
+    LogDebug("FlatEtaRangeGunProducer") << " : Event Generation Done " << std::endl;
+  }
+}

--- a/IOMC/ParticleGuns/src/SealModule.cc
+++ b/IOMC/ParticleGuns/src/SealModule.cc
@@ -13,6 +13,7 @@
 #include "IOMC/ParticleGuns/interface/FileRandomKEThetaGunProducer.h"
 #include "IOMC/ParticleGuns/interface/FileRandomMultiParticlePGunProducer.h"
 #include "IOMC/ParticleGuns/interface/FlatRandomMultiParticlePGunProducer.h"
+#include "IOMC/ParticleGuns/interface/FlatEtaRangeGunProducer.h"
 #include "IOMC/ParticleGuns/interface/FlatRandomOneOverPtGunProducer.h"
 #include "IOMC/ParticleGuns/interface/FlatRandomPtAndDxyGunProducer.h"
 #include "IOMC/ParticleGuns/interface/FlatRandomPtGunProducer.h"
@@ -45,6 +46,8 @@ using edm::FlatRandomEThetaGunProducer;
 DEFINE_FWK_MODULE(FlatRandomEThetaGunProducer);
 using edm::FlatRandomMultiParticlePGunProducer;
 DEFINE_FWK_MODULE(FlatRandomMultiParticlePGunProducer);
+using edm::FlatEtaRangeGunProducer;
+DEFINE_FWK_MODULE(FlatEtaRangeGunProducer);
 using edm::FlatRandomOneOverPtGunProducer;
 DEFINE_FWK_MODULE(FlatRandomOneOverPtGunProducer);
 using edm::FlatRandomPtAndDxyGunProducer;

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -98,7 +98,7 @@ namespace reco::mlpf {
     }
   };
 
-  static constexpr unsigned int NUM_OUTPUT_FEATURES = 15;
+  static constexpr unsigned int NUM_OUTPUT_FEATURES = 14;
 
   //these are defined at model creation time and set the random LSH codebook size
   static constexpr int LSH_BIN_SIZE = 100;
@@ -107,30 +107,22 @@ namespace reco::mlpf {
   //In CPU mode, we want to evaluate each event separately
   static constexpr int BATCH_SIZE = 1;
 
-  //The model has 14 outputs for each particle:
-  // out[0-7]: particle classification logits for each pdgId
-  // out[8]: regressed charge
-  // out[9]: regressed pt
-  // out[10]: regressed eta
-  // out[11]: regressed sin phi
-  // out[12]: regressed cos phi
-  // out[13]: regressed energy
-  static constexpr unsigned int IDX_CLASS = 8;
+  //index [0, N_pdgids) -> PDGID
+  //this maps the absolute values of the predicted PDGIDs to an array of ascending indices
+  static constexpr std::array<int, 8> pdgid_encoding{{0, 211, 130, 1, 2, 22, 11, 13}};
+  
+  static constexpr unsigned int IDX_CLASS_LAST = pdgid_encoding.size();
 
-  static constexpr unsigned int IDX_CHARGE = IDX_CLASS+1;
-
-  static constexpr unsigned int IDX_PT = IDX_CLASS+2;
-  static constexpr unsigned int IDX_ETA = IDX_CLASS+3;
-  static constexpr unsigned int IDX_SIN_PHI = IDX_CLASS+4;
-  static constexpr unsigned int IDX_COS_PHI = IDX_CLASS+5;
-  static constexpr unsigned int IDX_ENERGY = IDX_CLASS+6;
+  static constexpr unsigned int IDX_CHARGE = IDX_CLASS_LAST+1;
+  static constexpr unsigned int IDX_PT = IDX_CLASS_LAST+2;
+  static constexpr unsigned int IDX_ETA = IDX_CLASS_LAST+3;
+  static constexpr unsigned int IDX_SIN_PHI = IDX_CLASS_LAST+4;
+  static constexpr unsigned int IDX_COS_PHI = IDX_CLASS_LAST+5;
+  static constexpr unsigned int IDX_ENERGY = IDX_CLASS_LAST+6;
 
   //for consistency with the baseline PFAlgo
   static constexpr float PI_MASS = 0.13957;
 
-  //index [0, N_pdgids) -> PDGID
-  //this maps the absolute values of the predicted PDGIDs to an array of ascending indices
-  static const std::vector<int> pdgid_encoding = {0, 211, 130, 1, 2, 22, 11, 13, 15};
 
   //PFElement::type -> index [0, N_types)
   //this maps the type of the PFElement to an ascending index that is used by the model to distinguish between different elements

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -8,7 +8,7 @@
 namespace reco::mlpf {
 
   //The model takes the following number of features for each input PFElement
-  static constexpr unsigned int NUM_ELEMENT_FEATURES = 51;
+  static constexpr unsigned int NUM_ELEMENT_FEATURES = 41;
 
   struct ElementFeatures {
     float type;
@@ -66,7 +66,7 @@ namespace reco::mlpf {
     float etaerror4;
     float phierror4;
 
-    // MLPF features in 2024
+    // MLPF features in 2022
     std::array<float, NUM_ELEMENT_FEATURES> as_array() {
       return {{type,
                pt,
@@ -109,16 +109,17 @@ namespace reco::mlpf {
                lambdaerror,
                theta,
                thetaerror,
-               time,
-               timeerror,
-               etaerror1,
-               etaerror2,
-               etaerror3,
-               etaerror4,
-               phierror1,
-               phierror2,
-               phierror3,
-               phierror4}};
+//               time,
+//               timeerror,
+//               etaerror1,
+//               etaerror2,
+//               etaerror3,
+//               etaerror4,
+//               phierror1,
+//               phierror2,
+//               phierror3,
+//               phierror4
+        }};
     }
   };
 

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -7,6 +7,7 @@
 
 namespace reco::mlpf {
 
+  //The model takes the following number of features for each input PFElement
   static constexpr unsigned int NUM_ELEMENT_FEATURES = 41;
 
   struct ElementFeatures {
@@ -97,12 +98,11 @@ namespace reco::mlpf {
     }
   };
 
-  //The model takes the following number of features for each input PFElement
-  static constexpr unsigned int NUM_OUTPUT_FEATURES = 14;
+  static constexpr unsigned int NUM_OUTPUT_FEATURES = 15;
 
   //these are defined at model creation time and set the random LSH codebook size
-  static constexpr int LSH_BIN_SIZE = 64;
-  static constexpr int NUM_MAX_ELEMENTS_BATCH = 200 * LSH_BIN_SIZE;
+  static constexpr int LSH_BIN_SIZE = 32;
+  static constexpr int NUM_MAX_ELEMENTS_BATCH = 400 * LSH_BIN_SIZE;
 
   //In CPU mode, we want to evaluate each event separately
   static constexpr int BATCH_SIZE = 1;
@@ -115,22 +115,22 @@ namespace reco::mlpf {
   // out[11]: regressed sin phi
   // out[12]: regressed cos phi
   // out[13]: regressed energy
-  static constexpr unsigned int IDX_CLASS = 7;
+  static constexpr unsigned int IDX_CLASS = 8;
 
-  static constexpr unsigned int IDX_CHARGE = 8;
+  static constexpr unsigned int IDX_CHARGE = IDX_CLASS+1;
 
-  static constexpr unsigned int IDX_PT = 9;
-  static constexpr unsigned int IDX_ETA = 10;
-  static constexpr unsigned int IDX_SIN_PHI = 11;
-  static constexpr unsigned int IDX_COS_PHI = 12;
-  static constexpr unsigned int IDX_ENERGY = 13;
+  static constexpr unsigned int IDX_PT = IDX_CLASS+2;
+  static constexpr unsigned int IDX_ETA = IDX_CLASS+3;
+  static constexpr unsigned int IDX_SIN_PHI = IDX_CLASS+4;
+  static constexpr unsigned int IDX_COS_PHI = IDX_CLASS+5;
+  static constexpr unsigned int IDX_ENERGY = IDX_CLASS+6;
 
   //for consistency with the baseline PFAlgo
   static constexpr float PI_MASS = 0.13957;
 
   //index [0, N_pdgids) -> PDGID
   //this maps the absolute values of the predicted PDGIDs to an array of ascending indices
-  static const std::vector<int> pdgid_encoding = {0, 211, 130, 1, 2, 22, 11, 13};
+  static const std::vector<int> pdgid_encoding = {0, 211, 130, 1, 2, 22, 11, 13, 15};
 
   //PFElement::type -> index [0, N_types)
   //this maps the type of the PFElement to an ascending index that is used by the model to distinguish between different elements

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -57,6 +57,14 @@ namespace reco::mlpf {
     float thetaerror;
     float time;
     float timeerror;
+    float etaerror1;
+    float phierror1;
+    float etaerror2;
+    float phierror2;
+    float etaerror3;
+    float phierror3;
+    float etaerror4;
+    float phierror4;
 
     // MLPF features in 2022
     std::array<float, NUM_ELEMENT_FEATURES> as_array() {

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -6,8 +6,98 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 
 namespace reco::mlpf {
+
+  static constexpr unsigned int NUM_ELEMENT_FEATURES = 41;
+
+  struct ElementFeatures {
+    float type;
+    float pt;
+    float eta;
+    float phi;
+    float energy;
+    float layer;
+    float depth;
+    float charge;
+    float trajpoint;
+    float eta_ecal;
+    float phi_ecal;
+    float eta_hcal;
+    float phi_hcal;
+    float muon_dt_hits;
+    float muon_csc_hits;
+    float muon_type;
+    float px;
+    float py;
+    float pz;
+    float deltap;
+    float sigmadeltap;
+    float gsf_electronseed_trkorecal;
+    float gsf_electronseed_dnn1;
+    float gsf_electronseed_dnn2;
+    float gsf_electronseed_dnn3;
+    float gsf_electronseed_dnn4;
+    float gsf_electronseed_dnn5;
+    float num_hits;
+    float cluster_flags;
+    float corr_energy;
+    float corr_energy_err;
+    float vx;
+    float vy;
+    float vz;
+    float pterror;
+    float etaerror;
+    float phierror;
+    float lambda;
+    float lambdaerror;
+    float theta;
+    float thetaerror;
+
+    std::array<float, NUM_ELEMENT_FEATURES> as_array() {
+      return {{type,
+               pt,
+               eta,
+               phi,
+               energy,
+               layer,
+               depth,
+               charge,
+               trajpoint,
+               eta_ecal,
+               phi_ecal,
+               eta_hcal,
+               phi_hcal,
+               muon_dt_hits,
+               muon_csc_hits,
+               muon_type,
+               px,
+               py,
+               pz,
+               deltap,
+               sigmadeltap,
+               gsf_electronseed_trkorecal,
+               gsf_electronseed_dnn1,
+               gsf_electronseed_dnn2,
+               gsf_electronseed_dnn3,
+               gsf_electronseed_dnn4,
+               gsf_electronseed_dnn5,
+               num_hits,
+               cluster_flags,
+               corr_energy,
+               corr_energy_err,
+               vx,
+               vy,
+               vz,
+               pterror,
+               etaerror,
+               phierror,
+               lambda,
+               lambdaerror,
+               theta,
+               thetaerror}};
+    }
+  };
+
   //The model takes the following number of features for each input PFElement
-  static constexpr unsigned int NUM_ELEMENT_FEATURES = 25;
   static constexpr unsigned int NUM_OUTPUT_FEATURES = 14;
 
   //these are defined at model creation time and set the random LSH codebook size
@@ -59,7 +149,8 @@ namespace reco::mlpf {
       {11, 11},
   };
 
-  std::array<float, NUM_ELEMENT_FEATURES> getElementProperties(const reco::PFBlockElement& orig);
+  ElementFeatures getElementProperties(const reco::PFBlockElement& orig,
+                                       const edm::View<reco::GsfElectron>& gsfElectrons);
   float normalize(float in);
 
   int argMax(std::vector<float> const& vec);

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -131,16 +131,12 @@ namespace reco::mlpf {
   static constexpr unsigned int NUM_OUTPUT_FEATURES_CLS = 9;
   static constexpr unsigned int NUM_OUTPUT_FEATURES_P4 = 5;
 
-  //these are defined at model creation time and set the random LSH codebook size
-  static constexpr int LSH_BIN_SIZE = 256;
-  static constexpr int NUM_MAX_ELEMENTS_BATCH = 100 * LSH_BIN_SIZE;
-
   //In CPU mode, we want to evaluate each event separately
   static constexpr int BATCH_SIZE = 1;
 
   //index [0, N_pdgids) -> PDGID
   //this maps the absolute values of the predicted PDGIDs to an array of ascending indices
-  static constexpr std::array<int, 9> pdgid_encoding{{0, 211, 130, 1, 2, 22, 11, 13, 15}};
+  static constexpr std::array<int, 9> pdgid_encoding{{0, 211, 130, 1, 2, 22, 11, 13}};
   
   static constexpr unsigned int IDX_CLASS_LAST = pdgid_encoding.size()-1;
 

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -101,8 +101,8 @@ namespace reco::mlpf {
   static constexpr unsigned int NUM_OUTPUT_FEATURES = 15;
 
   //these are defined at model creation time and set the random LSH codebook size
-  static constexpr int LSH_BIN_SIZE = 32;
-  static constexpr int NUM_MAX_ELEMENTS_BATCH = 400 * LSH_BIN_SIZE;
+  static constexpr int LSH_BIN_SIZE = 100;
+  static constexpr int NUM_MAX_ELEMENTS_BATCH = 200 * LSH_BIN_SIZE;
 
   //In CPU mode, we want to evaluate each event separately
   static constexpr int BATCH_SIZE = 1;

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -111,7 +111,7 @@ namespace reco::mlpf {
   //this maps the absolute values of the predicted PDGIDs to an array of ascending indices
   static constexpr std::array<int, 8> pdgid_encoding{{0, 211, 130, 1, 2, 22, 11, 13}};
   
-  static constexpr unsigned int IDX_CLASS_LAST = pdgid_encoding.size();
+  static constexpr unsigned int IDX_CLASS_LAST = pdgid_encoding.size()-1;
 
   static constexpr unsigned int IDX_CHARGE = IDX_CLASS_LAST+1;
   static constexpr unsigned int IDX_PT = IDX_CLASS_LAST+2;

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -8,7 +8,7 @@
 namespace reco::mlpf {
 
   //The model takes the following number of features for each input PFElement
-  static constexpr unsigned int NUM_ELEMENT_FEATURES = 41;
+  static constexpr unsigned int NUM_ELEMENT_FEATURES = 51;
 
   struct ElementFeatures {
     float type;
@@ -66,7 +66,7 @@ namespace reco::mlpf {
     float etaerror4;
     float phierror4;
 
-    // MLPF features in 2022
+    // MLPF features in 2024
     std::array<float, NUM_ELEMENT_FEATURES> as_array() {
       return {{type,
                pt,
@@ -108,7 +108,17 @@ namespace reco::mlpf {
                lambda,
                lambdaerror,
                theta,
-               thetaerror}};
+               thetaerror,
+               time,
+               timeerror,
+               etaerror1,
+               etaerror2,
+               etaerror3,
+               etaerror4,
+               phierror1,
+               phierror2,
+               phierror3,
+               phierror4}};
     }
   };
 

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -30,6 +30,9 @@ namespace reco::mlpf {
     float px;
     float py;
     float pz;
+    float sigma_x;
+    float sigma_y;
+    float sigma_z;
     float deltap;
     float sigmadeltap;
     float gsf_electronseed_trkorecal;
@@ -52,7 +55,10 @@ namespace reco::mlpf {
     float lambdaerror;
     float theta;
     float thetaerror;
+    float time;
+    float timeerror;
 
+    // MLPF features in 2022
     std::array<float, NUM_ELEMENT_FEATURES> as_array() {
       return {{type,
                pt,

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -8,7 +8,7 @@
 namespace reco::mlpf {
 
   //The model takes the following number of features for each input PFElement
-  static constexpr unsigned int NUM_ELEMENT_FEATURES = 41;
+  static constexpr unsigned int NUM_ELEMENT_FEATURES = 55;
 
   struct ElementFeatures {
     float type;
@@ -66,12 +66,14 @@ namespace reco::mlpf {
     float etaerror4;
     float phierror4;
 
-    // MLPF features in 2022
+    // MLPF features in 2024
+    // from particleflow/mlpf/heptfds/cms_pf/utils.py
     std::array<float, NUM_ELEMENT_FEATURES> as_array() {
       return {{type,
                pt,
                eta,
-               phi,
+               std::sin(phi),
+               std::cos(phi),
                energy,
                layer,
                depth,
@@ -109,41 +111,44 @@ namespace reco::mlpf {
                lambdaerror,
                theta,
                thetaerror,
-//               time,
-//               timeerror,
-//               etaerror1,
-//               etaerror2,
-//               etaerror3,
-//               etaerror4,
-//               phierror1,
-//               phierror2,
-//               phierror3,
-//               phierror4
+               time,
+               timeerror,
+               etaerror1,
+               etaerror2,
+               etaerror3,
+               etaerror4,
+               phierror1,
+               phierror2,
+               phierror3,
+               phierror4,
+	       sigma_x,
+	       sigma_y,
+	       sigma_z,
         }};
     }
   };
 
-  static constexpr unsigned int NUM_OUTPUT_FEATURES = 14;
+  static constexpr unsigned int NUM_OUTPUT_FEATURES_CLS = 9;
+  static constexpr unsigned int NUM_OUTPUT_FEATURES_P4 = 5;
 
   //these are defined at model creation time and set the random LSH codebook size
-  static constexpr int LSH_BIN_SIZE = 100;
-  static constexpr int NUM_MAX_ELEMENTS_BATCH = 200 * LSH_BIN_SIZE;
+  static constexpr int LSH_BIN_SIZE = 256;
+  static constexpr int NUM_MAX_ELEMENTS_BATCH = 100 * LSH_BIN_SIZE;
 
   //In CPU mode, we want to evaluate each event separately
   static constexpr int BATCH_SIZE = 1;
 
   //index [0, N_pdgids) -> PDGID
   //this maps the absolute values of the predicted PDGIDs to an array of ascending indices
-  static constexpr std::array<int, 8> pdgid_encoding{{0, 211, 130, 1, 2, 22, 11, 13}};
+  static constexpr std::array<int, 9> pdgid_encoding{{0, 211, 130, 1, 2, 22, 11, 13, 15}};
   
   static constexpr unsigned int IDX_CLASS_LAST = pdgid_encoding.size()-1;
 
-  static constexpr unsigned int IDX_CHARGE = IDX_CLASS_LAST+1;
-  static constexpr unsigned int IDX_PT = IDX_CLASS_LAST+2;
-  static constexpr unsigned int IDX_ETA = IDX_CLASS_LAST+3;
-  static constexpr unsigned int IDX_SIN_PHI = IDX_CLASS_LAST+4;
-  static constexpr unsigned int IDX_COS_PHI = IDX_CLASS_LAST+5;
-  static constexpr unsigned int IDX_ENERGY = IDX_CLASS_LAST+6;
+  static constexpr unsigned int IDX_PT = 0;
+  static constexpr unsigned int IDX_ETA = 1;
+  static constexpr unsigned int IDX_SIN_PHI = 2;
+  static constexpr unsigned int IDX_COS_PHI = 3;
+  static constexpr unsigned int IDX_ENERGY = 4;
 
   //for consistency with the baseline PFAlgo
   static constexpr float PI_MASS = 0.13957;

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -136,7 +136,7 @@ namespace reco::mlpf {
 
   //index [0, N_pdgids) -> PDGID
   //this maps the absolute values of the predicted PDGIDs to an array of ascending indices
-  static constexpr std::array<int, 9> pdgid_encoding{{0, 211, 130, 1, 2, 22, 11, 13}};
+  static constexpr std::array<int, 9> pdgid_encoding{{0, 211, 130, 1, 2, 22, 11, 13, 15}};
   
   static constexpr unsigned int IDX_CLASS_LAST = pdgid_encoding.size()-1;
 

--- a/RecoParticleFlow/PFProducer/interface/MLPFModel.h
+++ b/RecoParticleFlow/PFProducer/interface/MLPFModel.h
@@ -179,7 +179,8 @@ namespace reco::mlpf {
                                   float pred_eta,
                                   float pred_sin_phi,
                                   float pred_cos_phi,
-                                  float pred_e);
+				  float pred_e,
+                                  float pred_ispu);
 
   const std::vector<const reco::PFBlockElement*> getPFElements(const reco::PFBlockCollection& blocks);
 

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -125,6 +125,7 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
       for (unsigned int idx_id = 0; idx_id < pred_id_probas.size(); idx_id++) {
         auto pred_proba = output_pid[ielem * NUM_OUTPUT_FEATURES_CLS + idx_id];
 #ifdef MLPF_DEBUG
+        std::cout << "pid proba: " << pred_proba << std::endl;
         assert(!std::isnan(pred_proba));
 #endif
         pred_id_probas[idx_id] = pred_proba;
@@ -135,6 +136,15 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
       //get the most probable class PDGID
       pred_pid = pdgid_encoding.at(imax);
     }
+
+#ifdef MLPF_DEBUG
+    std::cout << "p4: "
+      << output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + 0] << " "
+      << output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + 1] << " " 
+      << output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + 2] << " " 
+      << output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + 3] << " " 
+      << output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + 4] << std::endl;
+#endif
 
     //a particle was predicted for this PFElement, otherwise it was a spectator
     if (pred_pid != 0) {
@@ -169,10 +179,12 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
 
       //get the predicted momentum components from the model
       float pred_pt = output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + IDX_PT];
+      pred_pt = exp(pred_pt) * inputs[0][ielem * NUM_ELEMENT_FEATURES + 1]; 
       float pred_eta = output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + IDX_ETA];
       float pred_sin_phi = output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + IDX_SIN_PHI];
       float pred_cos_phi = output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + IDX_COS_PHI];
       float pred_e = output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + IDX_ENERGY];
+      pred_e = exp(pred_e) * inputs[0][ielem * NUM_ELEMENT_FEATURES + 5];
 
       auto cand = makeCandidate(pred_pid, pred_charge, pred_pt, pred_eta, pred_sin_phi, pred_cos_phi, pred_e);
       setCandidateRefs(cand, selected_elements, ielem);

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -12,7 +12,7 @@
 using namespace cms::Ort;
 
 //use this to switch on detailed print statements in MLPF
-#define MLPF_DEBUG
+//#define MLPF_DEBUG
 
 class MLPFProducer : public edm::stream::EDProducer<edm::GlobalCache<ONNXRuntime>> {
 public:

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -12,7 +12,7 @@
 using namespace cms::Ort;
 
 //use this to switch on detailed print statements in MLPF
-//#define MLPF_DEBUG
+#define MLPF_DEBUG
 
 class MLPFProducer : public edm::stream::EDProducer<edm::GlobalCache<ONNXRuntime>> {
 public:
@@ -95,10 +95,10 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
 
   std::vector<reco::PFCandidate> pOutputCandidateCollection;
   for (size_t ielem = 0; ielem < num_elements_total; ielem++) {
-    std::vector<float> pred_id_probas(IDX_CLASS + 1, 0.0);
+    std::vector<float> pred_id_probas(pdgid_encoding.size(), 0.0);
     const reco::PFBlockElement* elem = selected_elements[ielem];
 
-    for (unsigned int idx_id = 0; idx_id <= IDX_CLASS; idx_id++) {
+    for (unsigned int idx_id = 0; idx_id < pred_id_probas.size(); idx_id++) {
       auto pred_proba = output[ielem * NUM_OUTPUT_FEATURES + idx_id];
 #ifdef MLPF_DEBUG
       assert(!std::isnan(pred_proba));

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -212,7 +212,7 @@ void MLPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::InputTag>("src", edm::InputTag("particleFlowBlock"));
   desc.add<edm::FileInPath>("model_path",
                             edm::FileInPath("RecoParticleFlow/PFProducer/data/mlpf/"
-                                            "mlpf_110M_attn2x6x1024_bm5_relu_checkpoint18_8xmi250x_fp32_fused.onnx"));
+                                            "mlpf_5M_attn2x3x245_bm5_relu_checkpoint5_1xa100_fp32_fused.onnx"));
   desc.add<bool>("use_cuda", false);
   descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -191,8 +191,8 @@ void MLPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::InputTag>("src", edm::InputTag("particleFlowBlock"));
   desc.add<edm::FileInPath>("model_path",
                             edm::FileInPath("RecoParticleFlow/PFProducer/data/mlpf/"
-                                            "test_fp32_fused.onnx"));
-  desc.add<bool>("use_cuda", false);
+                                            "mlpf_21M_attn2x6x512_bs40_relu_tt_qcd_zh400k_checkpoint25_1xa100_fp32_fused.onnx"));
+  desc.add<bool>("use_cuda", true);
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -191,7 +191,7 @@ void MLPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::InputTag>("src", edm::InputTag("particleFlowBlock"));
   desc.add<edm::FileInPath>("model_path",
                             edm::FileInPath("RecoParticleFlow/PFProducer/data/mlpf/"
-                                            "mlpf_21M_attn2x6x512_bs40_relu_tt_qcd_zh400k_checkpoint25_1xa100_fp32_fused.onnx"));
+                                            "mlpf_28M_attn2x8x512_bm4_relu_tt_qcd_ttnopu_v2_0_0_checkpoint6_1xa100_fp32_fused.onnx"));
   desc.add<bool>("use_cuda", false);
   descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -12,7 +12,7 @@
 using namespace cms::Ort;
 
 //use this to switch on detailed print statements in MLPF
-#define MLPF_DEBUG
+//#define MLPF_DEBUG
 
 class MLPFProducer : public edm::stream::EDProducer<edm::GlobalCache<ONNXRuntime>> {
 public:
@@ -180,7 +180,8 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
 }
 
 std::unique_ptr<ONNXRuntime> MLPFProducer::initializeGlobalCache(const edm::ParameterSet& params) {
-  return std::make_unique<ONNXRuntime>(params.getParameter<edm::FileInPath>("model_path").fullPath());
+  auto session_options = ONNXRuntime::defaultSessionOptions(params.getParameter<bool>("use_cuda") ? Backend::cuda : Backend::cpu);
+  return std::make_unique<ONNXRuntime>(params.getParameter<edm::FileInPath>("model_path").fullPath(), &session_options);
 }
 
 void MLPFProducer::globalEndJob(const ONNXRuntime* cache) {}
@@ -191,6 +192,7 @@ void MLPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::FileInPath>("model_path",
                             edm::FileInPath("RecoParticleFlow/PFProducer/data/mlpf/"
                                             "test_fp32_fused.onnx"));
+  desc.add<bool>("use_cuda", false);
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -191,7 +191,7 @@ void MLPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::InputTag>("src", edm::InputTag("particleFlowBlock"));
   desc.add<edm::FileInPath>("model_path",
                             edm::FileInPath("RecoParticleFlow/PFProducer/data/mlpf/"
-                                            "mlpf_28M_attn2x8x512_bm4_relu_tt_qcd_ttnopu_v2_0_0_checkpoint6_1xa100_fp32_fused.onnx"));
+                                            "mlpf_110M_attn2x6x1024_bm5_relu_checkpoint18_8xmi250x_fp32_fused"));
   desc.add<bool>("use_cuda", false);
   descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -192,7 +192,7 @@ void MLPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::FileInPath>("model_path",
                             edm::FileInPath("RecoParticleFlow/PFProducer/data/mlpf/"
                                             "mlpf_21M_attn2x6x512_bs40_relu_tt_qcd_zh400k_checkpoint25_1xa100_fp32_fused.onnx"));
-  desc.add<bool>("use_cuda", true);
+  desc.add<bool>("use_cuda", false);
   descriptions.addWithDefaultLabel(desc);
 }
 

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -212,7 +212,7 @@ void MLPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::InputTag>("src", edm::InputTag("particleFlowBlock"));
   desc.add<edm::FileInPath>("model_path",
                             edm::FileInPath("RecoParticleFlow/PFProducer/data/mlpf/"
-                                            "mlpf_5M_attn2x3x245_bm5_relu_checkpoint5_1xa100_fp32_fused.onnx"));
+                                            "mlpf_5M_attn2x3x256_bm5_relu_checkpoint5_1xa100_fp32_fused.onnx"));
   desc.add<bool>("use_cuda", false);
   descriptions.addWithDefaultLabel(desc);
 }

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -47,7 +47,7 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   std::vector<const reco::PFBlockElement*> selected_elements;
   unsigned int num_elements_total = 0;
   for (const auto* pelem : all_elements) {
-    if (pelem->type() == reco::PFBlockElement::PS1 || pelem->type() == reco::PFBlockElement::PS2) {
+    if (pelem->type() == reco::PFBlockElement::PS1 || pelem->type() == reco::PFBlockElement::PS2 || pelem->type() == reco::PFBlockElement::BREM) {
       continue;
     }
     num_elements_total += 1;
@@ -117,7 +117,6 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
       std::cout << iprop << "=" << inputs[0][ielem * NUM_ELEMENT_FEATURES + iprop] << " ";
     }
     std::cout << std::endl;
-    std::cout << "ielem=" << ielem << " pred: pid=" << pred_pid << std::endl;
 #endif
 
     //a particle was predicted for this PFElement, otherwise it was a spectator
@@ -154,7 +153,7 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
       pOutputCandidateCollection.push_back(cand);
 
 #ifdef MLPF_DEBUG
-      std::cout << "ielem=" << ielem << " cand: pid=" << cand.pdgId() << " E=" << cand.energy() << " pt=" << cand.pt()
+      std::cout << "ielem=" << ielem << " pred: pid=" << cand.pdgId() << " E=" << cand.energy() << " pt=" << cand.pt()
                 << " eta=" << cand.eta() << " phi=" << cand.phi() << " charge=" << cand.charge() << std::endl;
 #endif
     }

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -12,7 +12,7 @@
 using namespace cms::Ort;
 
 //use this to switch on detailed print statements in MLPF
-//#define MLPF_DEBUG
+#define MLPF_DEBUG
 
 class MLPFProducer : public edm::stream::EDProducer<edm::GlobalCache<ONNXRuntime>> {
 public:
@@ -45,19 +45,25 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   const auto& gsfElectrons = event.get(gsfElectrons_);
 
   std::vector<const reco::PFBlockElement*> selected_elements;
-  unsigned int num_elements_total = 0;
+  unsigned int num_elements_total = all_elements.size();
+  unsigned int num_elements_skipped = 0;
+  unsigned int num_elements_selected = 0;
   for (const auto* pelem : all_elements) {
     if (pelem->type() == reco::PFBlockElement::PS1 || pelem->type() == reco::PFBlockElement::PS2 || pelem->type() == reco::PFBlockElement::BREM) {
+      num_elements_skipped += 1;
       continue;
     }
-    num_elements_total += 1;
+    num_elements_selected += 1;
     selected_elements.push_back(pelem);
   }
-  const auto tensor_size = num_elements_total;
 
 #ifdef MLPF_DEBUG
-  std::cout << "tensor_size=" << tensor_size << std::endl;
+  std::cout << "num_elements_total=" << num_elements_total
+            << " num_elements_skipped=" << num_elements_skipped
+            << " num_elements_selected=" << num_elements_selected << std::endl;
 #endif
+  
+  const auto tensor_size = num_elements_selected;
 
   //Fill the input tensor (batch, elems, features) = (1, tensor_size, NUM_ELEMENT_FEATURES)
   std::vector<std::vector<float>> inputs;
@@ -68,6 +74,7 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     if (ielem > tensor_size) {
       continue;
     }
+    std::cout << "ielem=" << ielem << std::endl;
 
     const auto& elem = *pelem;
 
@@ -76,12 +83,19 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
 
     //copy features to the input array
     for (unsigned int iprop = 0; iprop < NUM_ELEMENT_FEATURES; iprop++) {
-      inputs[0][ielem * NUM_ELEMENT_FEATURES + iprop] = normalize(props[iprop]);
+      const auto vec_elem = ielem * NUM_ELEMENT_FEATURES + iprop;
+      assert(vec_elem < inputs[0].size()); 
+      inputs[0][vec_elem] = normalize(props[iprop]);
     }
     //mask
     inputs[1][ielem] = 1.0;
     ielem += 1;
   }
+
+  for (unsigned int _idx=0; _idx < inputs[0].size(); _idx++) {
+    std::cout << inputs[0][_idx] << " " << std::endl;
+  }
+  std::cout << std::endl;
 
   //run the GNN inference, given the inputs and the output.
   const auto& outputs = globalCache()->run({"Xfeat_normed", "mask"}, inputs, {{1, tensor_size, NUM_ELEMENT_FEATURES}, {1, tensor_size}});

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -93,7 +93,7 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   }
 
   for (unsigned int _idx=0; _idx < inputs[0].size(); _idx++) {
-    std::cout << inputs[0][_idx] << " " << std::endl;
+    std::cout << inputs[0][_idx] << " ";
   }
   std::cout << std::endl;
 
@@ -115,7 +115,7 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
 #endif
 
   std::vector<reco::PFCandidate> pOutputCandidateCollection;
-  for (size_t ielem = 0; ielem < num_elements_total; ielem++) {
+  for (size_t ielem = 0; ielem < num_elements_selected; ielem++) {
     std::vector<float> pred_id_probas(pdgid_encoding.size(), 0.0);
     const reco::PFBlockElement* elem = selected_elements[ielem];
 

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -12,7 +12,7 @@
 using namespace cms::Ort;
 
 //use this to switch on detailed print statements in MLPF
-#define MLPF_DEBUG
+//#define MLPF_DEBUG
 
 class MLPFProducer : public edm::stream::EDProducer<edm::GlobalCache<ONNXRuntime>> {
 public:
@@ -74,7 +74,9 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     if (ielem > tensor_size) {
       continue;
     }
+#ifdef MLPF_DEBUG
     std::cout << "ielem=" << ielem << std::endl;
+#endif
 
     const auto& elem = *pelem;
 
@@ -92,10 +94,12 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     ielem += 1;
   }
 
+#ifdef MLPF_DEBUG
   for (unsigned int _idx=0; _idx < inputs[0].size(); _idx++) {
     std::cout << inputs[0][_idx] << " ";
   }
   std::cout << std::endl;
+#endif
 
   //run the GNN inference, given the inputs and the output.
   const auto& outputs = globalCache()->run({"Xfeat_normed", "mask"}, inputs, {{1, tensor_size, NUM_ELEMENT_FEATURES}, {1, tensor_size}});

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -204,13 +204,18 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
       float pred_e = output_p4[ielem * NUM_OUTPUT_FEATURES_P4 + IDX_ENERGY];
       pred_e = exp(pred_e) * inputs[0][ielem * NUM_ELEMENT_FEATURES + 5];
 
-      auto cand = makeCandidate(pred_pid, pred_charge, pred_pt, pred_eta, pred_sin_phi, pred_cos_phi, pred_e);
+      //get the predicted PU probability
+      //set to 0 now until new training is available
+      float pred_ispu = 0;
+
+      auto cand = makeCandidate(pred_pid, pred_charge, pred_pt, pred_eta, pred_sin_phi, pred_cos_phi, pred_e, pred_ispu);
       setCandidateRefs(cand, selected_elements, ielem);
       pOutputCandidateCollection.push_back(cand);
 
 #ifdef MLPF_DEBUG
       std::cout << "ielem=" << ielem << " pred: pid=" << cand.pdgId() << " E=" << cand.energy() << " pt=" << cand.pt()
-                << " eta=" << cand.eta() << " phi=" << cand.phi() << " charge=" << cand.charge() << std::endl;
+                << " eta=" << cand.eta() << " phi=" << cand.phi() << " charge=" << cand.charge()
+		<< "ispu=" << cand.MlpfPuPred() << std::endl;
 #endif
     }
   }  //loop over PFElements

--- a/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/MLPFProducer.cc
@@ -106,6 +106,7 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
   const auto& output_binary = outputs[0];
   const auto& output_pid = outputs[1];
   const auto& output_p4 = outputs[2];
+  const auto& output_pu = outputs[3];
 
 #ifdef MLPF_DEBUG
   std::cout << "output_binary=" << output_binary.size() << std::endl;  
@@ -116,6 +117,9 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
 
   std::cout << "output_p4=" << output_p4.size() << std::endl;  
   assert(output_p4.size() == tensor_size * NUM_OUTPUT_FEATURES_P4);
+
+  std::cout << "output_pu=" << output_pu.size() << std::endl;
+  assert(output_pu.size() == tensor_size * 2);
 #endif
 
   std::vector<reco::PFCandidate> pOutputCandidateCollection;
@@ -205,8 +209,14 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
       pred_e = exp(pred_e) * inputs[0][ielem * NUM_ELEMENT_FEATURES + 5];
 
       //get the predicted PU probability
-      //set to 0 now until new training is available
-      float pred_ispu = 0;
+      const auto logit_no_pu = output_pu[ielem * 2 + 0];
+      const auto logit_pu = output_pu[ielem * 2 + 1];
+      float pred_ispu = exp(logit_pu)/(exp(logit_no_pu)+exp(logit_pu));
+
+#ifdef MLPF_DEBUG
+      std::cout << "pu: " << logit_no_pu << " " << logit_pu << std::endl;
+      std::cout << "ispu prob: " << pred_ispu << std::endl;
+#endif
 
       auto cand = makeCandidate(pred_pid, pred_charge, pred_pt, pred_eta, pred_sin_phi, pred_cos_phi, pred_e, pred_ispu);
       setCandidateRefs(cand, selected_elements, ielem);
@@ -215,7 +225,7 @@ void MLPFProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
 #ifdef MLPF_DEBUG
       std::cout << "ielem=" << ielem << " pred: pid=" << cand.pdgId() << " E=" << cand.energy() << " pt=" << cand.pt()
                 << " eta=" << cand.eta() << " phi=" << cand.phi() << " charge=" << cand.charge()
-		<< "ispu=" << cand.MlpfPuPred() << std::endl;
+		<< " ispu=" << cand.mlpf_pu() << std::endl;
 #endif
     }
   }  //loop over PFElements

--- a/RecoParticleFlow/PFProducer/src/MLPFModel.cc
+++ b/RecoParticleFlow/PFProducer/src/MLPFModel.cc
@@ -267,6 +267,7 @@ namespace reco::mlpf {
           posEta[ihit] = RefPFRecHit->position().eta();
           posPhi[ihit] = deltaPhi(RefPFRecHit->position().phi(), ref->phi());
           depths[ihit] = RefPFRecHit->depth();
+          // std::cout << "CLH " << type << " d=" << RefPFRecHit->depth() << " l=" << RefPFRecHit->layer() << " e=" << energyHit << " px=" <<  RefPFRecHit->position().x() << " py=" <<  RefPFRecHit->position().y() << " pz=" <<  RefPFRecHit->position().z() << std::endl;
 
           if (depths[ihit] == 1) {
             depth1_hitE.push_back(hitE[ihit]);

--- a/RecoParticleFlow/PFProducer/src/MLPFModel.cc
+++ b/RecoParticleFlow/PFProducer/src/MLPFModel.cc
@@ -406,11 +406,6 @@ namespace reco::mlpf {
 
   //to make sure DNN inputs are within numerical bounds, use the same in training
   float normalize(float in) {
-    if (std::abs(in) > 1e4f) {
-      return 0.0;
-    } else if (edm::isNotFinite(in)) {
-      return 0.0;
-    }
     return in;
   }
 
@@ -455,6 +450,7 @@ namespace reco::mlpf {
     cand.setMass(0.0);
     if (pred_pid == 211)
       cand.setMass(PI_MASS);
+
     //cand.setPdgId(pred_pid);
     //cand.setCharge(charge);
 

--- a/RecoParticleFlow/PFProducer/src/MLPFModel.cc
+++ b/RecoParticleFlow/PFProducer/src/MLPFModel.cc
@@ -468,13 +468,7 @@ namespace reco::mlpf {
     for (const auto& block : blocks) {
       const auto& elems = block.elements();
       for (const auto& elem : elems) {
-        if (all_elements.size() < NUM_MAX_ELEMENTS_BATCH) {
-          all_elements.push_back(&elem);
-        } else {
-          //model needs to be created with a bigger LSH codebook size
-          edm::LogError("MLPFProducer") << "too many input PFElements for predefined model size:" << elems.size();
-          break;
-        }
+        all_elements.push_back(&elem);
       }
     }
     return all_elements;

--- a/RecoParticleFlow/PFProducer/src/MLPFModel.cc
+++ b/RecoParticleFlow/PFProducer/src/MLPFModel.cc
@@ -64,6 +64,14 @@ namespace reco::mlpf {
     float num_hits = 0.0;
     float time = 0.0;
     float timeerror = 0.0;
+    float etaerror1 = 0.0;
+    float phierror1 = 0.0;
+    float etaerror2 = 0.0;
+    float phierror2 = 0.0;
+    float etaerror3 = 0.0;
+    float phierror3 = 0.0;
+    float etaerror4 = 0.0;
+    float phierror4 = 0.0;
 
     if (type == reco::PFBlockElement::TRACK) {
       const auto& matched_pftrack = orig.trackRefPF();
@@ -232,6 +240,20 @@ namespace reco::mlpf {
         std::vector<double> posX(ref->recHitFractions().size(), 0.0);
         std::vector<double> posY(ref->recHitFractions().size(), 0.0);
         std::vector<double> posZ(ref->recHitFractions().size(), 0.0);
+        std::vector<double> depths(ref->recHitFractions().size(), 0.0);
+        
+        std::vector<double> depth1_hitE;
+        std::vector<double> depth1_posEta;
+        std::vector<double> depth1_posPhi;
+        std::vector<double> depth2_hitE;
+        std::vector<double> depth2_posEta;
+        std::vector<double> depth2_posPhi;
+        std::vector<double> depth3_hitE;
+        std::vector<double> depth3_posEta;
+        std::vector<double> depth3_posPhi;
+        std::vector<double> depth4_hitE;
+        std::vector<double> depth4_posEta;
+        std::vector<double> depth4_posPhi;
 
         const std::vector<reco::PFRecHitFraction>& PFRecHits = ref->recHitFractions();
         unsigned int ihit = 0;
@@ -243,7 +265,30 @@ namespace reco::mlpf {
           posY[ihit] = RefPFRecHit->position().y();
           posZ[ihit] = RefPFRecHit->position().z();
           posEta[ihit] = RefPFRecHit->position().eta();
-          posPhi[ihit] = RefPFRecHit->position().phi();
+          posPhi[ihit] = deltaPhi(RefPFRecHit->position().phi(), ref->phi());
+          depths[ihit] = RefPFRecHit->depth();
+
+          if (depths[ihit] == 1) {
+            depth1_hitE.push_back(hitE[ihit]);
+            depth1_posEta.push_back(posEta[ihit]);
+            depth1_posPhi.push_back(posPhi[ihit]);
+          }
+          else if (depths[ihit] == 2) {
+            depth2_hitE.push_back(hitE[ihit]);
+            depth2_posEta.push_back(posEta[ihit]);
+            depth2_posPhi.push_back(posPhi[ihit]);
+          }
+          else if (depths[ihit] == 3) {
+            depth3_hitE.push_back(hitE[ihit]);
+            depth3_posEta.push_back(posEta[ihit]);
+            depth3_posPhi.push_back(posPhi[ihit]);
+          }
+          else {
+            depth4_hitE.push_back(hitE[ihit]);
+            depth4_posEta.push_back(posEta[ihit]);
+            depth4_posPhi.push_back(posPhi[ihit]);
+          }
+
           ihit++;
         }
         if (ref->recHitFractions().size() > 1) {
@@ -252,7 +297,23 @@ namespace reco::mlpf {
           sigma_z = TMath::StdDev(posZ.begin(), posZ.end(), hitE.begin());
           pterror = TMath::StdDev(hitE.begin(), hitE.end());
           etaerror = TMath::StdDev(posEta.begin(), posEta.end());
-          phierror = TMath::StdDev(posPhi.begin(), posPhi.end()); //NB: this does not correctly account for modular phi at the moment
+          phierror = TMath::StdDev(posPhi.begin(), posPhi.end());
+        }
+        if (depth1_hitE.size() > 1) {
+          etaerror1 = TMath::StdDev(depth1_posEta.begin(), depth1_posEta.end(), depth1_hitE.begin());
+          phierror1 = TMath::StdDev(depth1_posPhi.begin(), depth1_posPhi.end(), depth1_hitE.begin());
+        }
+        if (depth2_hitE.size() > 1) {
+          etaerror2 = TMath::StdDev(depth2_posEta.begin(), depth2_posEta.end(), depth2_hitE.begin());
+          phierror2 = TMath::StdDev(depth2_posPhi.begin(), depth2_posPhi.end(), depth2_hitE.begin());
+        }
+        if (depth3_hitE.size() > 1) {
+          etaerror3 = TMath::StdDev(depth3_posEta.begin(), depth3_posEta.end(), depth3_hitE.begin());
+          phierror3 = TMath::StdDev(depth3_posPhi.begin(), depth3_posPhi.end(), depth3_hitE.begin());
+        }
+        if (depth4_hitE.size() > 1) {
+          etaerror4 = TMath::StdDev(depth4_posEta.begin(), depth4_posEta.end(), depth4_hitE.begin());
+          phierror4 = TMath::StdDev(depth4_posPhi.begin(), depth4_posPhi.end(), depth4_hitE.begin());
         }
       } 
     } else if (type == reco::PFBlockElement::SC) {
@@ -330,6 +391,14 @@ namespace reco::mlpf {
     ret.thetaerror = thetaerror;
     ret.time = time;
     ret.timeerror = timeerror;
+    ret.etaerror1 = etaerror1;
+    ret.phierror1 = phierror1;
+    ret.etaerror2 = etaerror2;
+    ret.phierror2 = phierror2;
+    ret.etaerror3 = etaerror3;
+    ret.phierror3 = phierror3;
+    ret.etaerror4 = etaerror4;
+    ret.phierror4 = phierror4;
 
     return ret;
   }

--- a/RecoParticleFlow/PFProducer/src/MLPFModel.cc
+++ b/RecoParticleFlow/PFProducer/src/MLPFModel.cc
@@ -419,7 +419,8 @@ namespace reco::mlpf {
                                   float pred_eta,
                                   float pred_sin_phi,
                                   float pred_cos_phi,
-                                  float pred_e) {
+				  float pred_e,
+				  float pred_ispu) {
     float pred_phi = std::atan2(pred_sin_phi, pred_cos_phi);
 
     //set the charge to +1 or -1 for PFCandidates that are charged, according to the sign of the predicted charge
@@ -451,6 +452,7 @@ namespace reco::mlpf {
     if (pred_pid == 211)
       cand.setMass(PI_MASS);
 
+    cand.set_mlpf_pu(pred_ispu);
     //cand.setPdgId(pred_pid);
     //cand.setCharge(charge);
 

--- a/SimGeneral/MixingModule/python/mix_Run3_Flat0To150_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_Run3_Flat0To150_PoissonOOTPU_cfi.py
@@ -1,0 +1,8 @@
+# A simple distribution for Run3 studies consisting of a flat distribution from 0
+# to 150 for the average pileup.
+
+import FWCore.ParameterSet.Config as cms
+from SimGeneral.MixingModule.mix_probFunction_25ns_PoissonOOTPU_cfi import *
+mix.input.nbPileupEvents.probFunctionVariable = cms.vint32(range(151))
+mix.input.nbPileupEvents.probValue = cms.vdouble([1.0/150.0 for _ in range(151)])
+

--- a/Validation/RecoParticleFlow/plugins/BuildFile.xml
+++ b/Validation/RecoParticleFlow/plugins/BuildFile.xml
@@ -11,8 +11,6 @@
   <use name="DataFormats/ParticleFlowCandidate"/>
   <use name="RecoParticleFlow/Benchmark"/>
   <use name="CommonTools/UtilAlgos"/>
-  <use name="Geometry/HcalTowerAlgo"/>
-  <use name="MagneticField/Records"/>
   <flags EDM_PLUGIN="1"/>
 </library>
 

--- a/Validation/RecoParticleFlow/plugins/BuildFile.xml
+++ b/Validation/RecoParticleFlow/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
   <use name="DataFormats/ParticleFlowReco"/>
   <use name="DataFormats/ParticleFlowCandidate"/>
   <use name="RecoParticleFlow/Benchmark"/>
+  <use name="RecoParticleFlow/PFProducer"/>
   <use name="CommonTools/UtilAlgos"/>
   <flags EDM_PLUGIN="1"/>
 </library>

--- a/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
@@ -826,7 +826,6 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   for (size_t ielem = 0; ielem < all_elements.size(); ielem++) {
     const auto& elem = all_elements.at(ielem);
     const auto& orig = elem.orig;
-    reco::PFBlockElement::Type type = orig.type();
 
     const auto& found = pfcluster_to_rechit.find(ielem);
     if (found != pfcluster_to_rechit.end()) {

--- a/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
@@ -665,7 +665,7 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       daughters[j] = static_cast<int>(it_p->daughterRefVector().at(j).key());
     }
     gen_daughters_.push_back(daughters);
-    // std::cout << "gp pt=" << it_p->pt() << " pid=" << it_p->pdgId() << " dau=" << daughters.size() << std::endl;
+    LOG << "gp pt=" << it_p->pt() << " pid=" << it_p->pdgId() << " dau=" << daughters.size() << std::endl;
   }
 
   edm::Handle<edm::View<reco::GenJet>> genJetsHandle;
@@ -795,8 +795,7 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     caloparticle_pid_.push_back(cp.pdgId());
     caloparticle_charge_.push_back(cp.charge());
 
-    // LOG << "cp=" << ncaloparticle << " pt=" << cp.p4().pt() << " typ=" << cp.pdgId();
-    // std::cout << "cp=" << ncaloparticle << " pt=" << cp.p4().pt() << " typ=" << cp.pdgId() << " gen=" << cp.genParticles().size() << " tid=" << cp.g4Tracks().at(0).trackId() << std::endl;
+    LOG << "cp=" << ncaloparticle << " pt=" << cp.p4().pt() << " typ=" << cp.pdgId();
 
     const auto& simtrack = cp.g4Tracks().at(0);
 
@@ -823,7 +822,7 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       simcluster_bx_.push_back(simcluster.eventId().bunchCrossing());
       simcluster_ev_.push_back(simcluster.eventId().event());
       simcluster_idx_caloparticle_.push_back(ncaloparticle);
-      // std::cout << "  sc pt=" << simcluster.p4().pt() << " typ=" << simcluster.pdgId() << " gen=" << simcluster.genParticles().size() << " tid=" << simcluster.g4Tracks().at(0).trackId() << std::endl;
+      LOG << "  sc pt=" << simcluster.p4().pt() << " typ=" << simcluster.pdgId() << " gen=" << simcluster.genParticles().size() << " tid=" << simcluster.g4Tracks().at(0).trackId() << std::endl;
       
       int simcluster_to_trackingparticle = -1;
       for (size_t itp = 0; itp < trackingParticles.size(); itp++) {
@@ -838,7 +837,7 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       simcluster_idx_trackingparticle_.push_back(simcluster_to_trackingparticle);
 
       for (const auto& hf : simcluster.hits_and_fractions()) {
-        LOG << "  cp=" << ncaloparticle << " detid=" << hf.first << " " << hf.second;
+        LOG << "  cp=" << ncaloparticle << " sc=" << nsimcluster << " detid=" << hf.first << " " << hf.second;
         simhit_to_caloparticle[hf.first].push_back({ncaloparticle, hf.second});
         simhit_to_simcluster[hf.first].push_back({nsimcluster, hf.second});
       }
@@ -897,6 +896,7 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
             if (caloparticle_to_pfcluster.find(key) == caloparticle_to_pfcluster.end()) {
               caloparticle_to_pfcluster[key] = 0.0;
             }
+	    LOG << "cp match " << key.first << " " << key.second << " " << rechit_frac.second << " " << simhit_frac.second;
             caloparticle_to_pfcluster[key] += rechit_frac.second * simhit_frac.second;
           }
         }
@@ -908,6 +908,7 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
             if (simcluster_to_pfcluster.find(key) == simcluster_to_pfcluster.end()) {
               simcluster_to_pfcluster[key] = 0.0;
             }
+	    LOG << "sc match " << key.first << " " << key.second << " " << rechit_frac.second << " " << simhit_frac.second;
             simcluster_to_pfcluster[key] += rechit_frac.second * simhit_frac.second;
           }
         }
@@ -1059,7 +1060,7 @@ void PFAnalysis::processTrackingParticles(const edm::View<TrackingParticle>& tra
 
     trackingparticle_pid_.push_back(tp.pdgId());
     trackingparticle_charge_.push_back(tp.charge());
-    // std::cout << "tp=" << ntrackingparticle << " pt=" << tp.p4().pt() << " typ=" << tp.pdgId() << " gen=" << tp.genParticles().size() << " tid=" << tp.g4Tracks().at(0).trackId() << std::endl;
+    LOG << "tp=" << ntrackingparticle << " pt=" << tp.p4().pt() << " typ=" << tp.pdgId() << " gen=" << tp.genParticles().size() << " tid=" << tp.g4Tracks().at(0).trackId() << std::endl;
   }
 }
 

--- a/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
@@ -191,6 +191,8 @@ private:
   vector<float> caloparticle_pt_;
   vector<float> caloparticle_energy_;
   vector<float> caloparticle_simenergy_;
+  vector<float> caloparticle_bx_;
+  vector<float> caloparticle_ev_;
   vector<int> caloparticle_pid_;
   vector<int> caloparticle_idx_trackingparticle_;
 
@@ -235,15 +237,19 @@ private:
   vector<vector<int>> gen_daughters_;
 
   vector<float> element_pt_;
+  vector<float> element_pterror_;
   vector<float> element_px_;
   vector<float> element_py_;
   vector<float> element_pz_;
   vector<float> element_deltap_;
   vector<float> element_sigmadeltap_;
   vector<float> element_eta_;
+  vector<float> element_etaerror_;
   vector<float> element_phi_;
+  vector<float> element_phierror_;
   vector<float> element_energy_;
   vector<float> element_corr_energy_;
+  vector<float> element_corr_energy_err_;
   vector<float> element_eta_ecal_;
   vector<float> element_phi_ecal_;
   vector<float> element_eta_hcal_;
@@ -264,6 +270,13 @@ private:
   vector<float> element_gsf_electronseed_dnn4_;
   vector<float> element_gsf_electronseed_dnn5_;
   vector<float> element_num_hits_;
+  vector<float> element_lambda_;
+  vector<float> element_lambdaerror_;
+  vector<float> element_theta_;
+  vector<float> element_thetaerror_;
+  vector<float> element_vx_;
+  vector<float> element_vy_;
+  vector<float> element_vz_;
 
   vector<int> element_distance_i_;
   vector<int> element_distance_j_;
@@ -342,6 +355,8 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
   t_->Branch("caloparticle_pt", &caloparticle_pt_);
   t_->Branch("caloparticle_energy", &caloparticle_energy_);
   t_->Branch("caloparticle_simenergy", &caloparticle_simenergy_);
+  t_->Branch("caloparticle_bx", &caloparticle_bx_);
+  t_->Branch("caloparticle_ev", &caloparticle_ev_);
   t_->Branch("caloparticle_pid", &caloparticle_pid_);
   t_->Branch("caloparticle_idx_trackingparticle", &caloparticle_idx_trackingparticle_);
 
@@ -389,15 +404,19 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
 
   //PF Elements
   t_->Branch("element_pt", &element_pt_);
+  t_->Branch("element_pterror", &element_pterror_);
   t_->Branch("element_px", &element_px_);
   t_->Branch("element_py", &element_py_);
   t_->Branch("element_pz", &element_pz_);
   t_->Branch("element_deltap", &element_deltap_);
   t_->Branch("element_sigmadeltap", &element_sigmadeltap_);
   t_->Branch("element_eta", &element_eta_);
+  t_->Branch("element_etaerror", &element_etaerror_);
   t_->Branch("element_phi", &element_phi_);
+  t_->Branch("element_phierror", &element_phierror_);
   t_->Branch("element_energy", &element_energy_);
   t_->Branch("element_corr_energy", &element_corr_energy_);
+  t_->Branch("element_corr_energy_err", &element_corr_energy_err_);
   t_->Branch("element_eta_ecal", &element_eta_ecal_);
   t_->Branch("element_phi_ecal", &element_phi_ecal_);
   t_->Branch("element_eta_hcal", &element_eta_hcal_);
@@ -418,6 +437,13 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
   t_->Branch("element_gsf_electronseed_dnn4", &element_gsf_electronseed_dnn4_);
   t_->Branch("element_gsf_electronseed_dnn5", &element_gsf_electronseed_dnn5_);
   t_->Branch("element_num_hits", &element_num_hits_);
+  t_->Branch("element_lambda", &element_lambda_);
+  t_->Branch("element_lambdaerror", &element_lambdaerror_);
+  t_->Branch("element_theta", &element_theta_);
+  t_->Branch("element_thetaerror", &element_thetaerror_);
+  t_->Branch("element_vx", &element_vx_);
+  t_->Branch("element_vy", &element_vy_);
+  t_->Branch("element_vz", &element_vz_);
 
   //Distance matrix between PF elements
   t_->Branch("element_distance_i", &element_distance_i_);
@@ -491,6 +517,8 @@ void PFAnalysis::clearVariables() {
   caloparticle_phi_.clear();
   caloparticle_energy_.clear();
   caloparticle_simenergy_.clear();
+  caloparticle_bx_.clear();
+  caloparticle_ev_.clear();
   caloparticle_pid_.clear();
   caloparticle_idx_trackingparticle_.clear();
 
@@ -537,15 +565,19 @@ void PFAnalysis::clearVariables() {
   gen_daughters_.clear();
 
   element_pt_.clear();
+  element_pterror_.clear();
   element_px_.clear();
   element_py_.clear();
   element_pz_.clear();
   element_deltap_.clear();
   element_sigmadeltap_.clear();
   element_eta_.clear();
+  element_etaerror_.clear();
   element_phi_.clear();
+  element_phierror_.clear();
   element_energy_.clear();
   element_corr_energy_.clear();
+  element_corr_energy_err_.clear();
   element_eta_ecal_.clear();
   element_phi_ecal_.clear();
   element_eta_hcal_.clear();
@@ -566,6 +598,13 @@ void PFAnalysis::clearVariables() {
   element_gsf_electronseed_dnn4_.clear();
   element_gsf_electronseed_dnn5_.clear();
   element_num_hits_.clear();
+  element_lambda_.clear();
+  element_lambdaerror_.clear();
+  element_theta_.clear();
+  element_thetaerror_.clear();
+  element_vx_.clear();
+  element_vy_.clear();
+  element_vz_.clear();
 
   element_distance_i_.clear();
   element_distance_j_.clear();
@@ -683,6 +722,9 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     caloparticle_phi_.push_back(cp.p4().phi());
     caloparticle_energy_.push_back(cp.p4().energy());
     caloparticle_simenergy_.push_back(cp.simEnergy());
+
+    caloparticle_ev_.push_back(cp.eventId().event());
+    caloparticle_bx_.push_back(cp.eventId().bunchCrossing());
     caloparticle_pid_.push_back(cp.pdgId());
 
     const auto& simtrack = cp.g4Tracks().at(0);
@@ -746,15 +788,26 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     reco::PFBlockElement::Type type = orig.type();
 
     float pt = 0.0;
+    float ptError = 0.0;
     float deltap = 0.0;
     float sigmadeltap = 0.0;
     float px = 0.0;
     float py = 0.0;
     float pz = 0.0;
     float eta = 0.0;
+    float etaError = 0.0;
     float phi = 0.0;
+    float phiError = 0.0;
+    float lambda = 0.0;
+    float lambdaError = 0.0;
+    float theta = 0.0;
+    float thetaError = 0.0;
     float energy = 0.0;
+    float vx = 0.0;
+    float vy = 0.0;
+    float vz = 0.0;
     float corr_energy = 0.0;
+    float corr_energy_err = 0.0;
     float trajpoint = 0.0;
     float eta_ecal = 0.0;
     float phi_ecal = 0.0;
@@ -791,14 +844,24 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       }
       const auto& ref = ((const reco::PFBlockElementTrack*)&orig)->trackRef();
       pt = ref->pt();
+      ptError = ref->ptError();
       px = ref->px();
       py = ref->py();
       pz = ref->pz();
       eta = ref->eta();
+      etaError = ref->etaError();
       phi = ref->phi();
+      phiError = ref->phiError();
       energy = ref->p();
       charge = ref->charge();
       num_hits = ref->recHitsSize();
+      lambda = ref->lambda();
+      lambdaError = ref->lambdaError();
+      theta = ref->theta();
+      thetaError = ref->thetaError();
+      vx = ref->vx();
+      vy = ref->vy();
+      vz = ref->vz();
 
       reco::MuonRef muonRef = orig.muonRef();
       if (muonRef.isNonnull()) {
@@ -842,25 +905,39 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     } else if (type == reco::PFBlockElement::GSF) {
       //requires to keep GsfPFRecTracks
       const auto* orig2 = (const reco::PFBlockElementGsfTrack*)&orig;
+      const auto& ref = orig2->GsftrackRef();
+
+      pt = ref->ptMode();
+      ptError = ref->ptModeError();
+      px = ref->pxMode();
+      py = ref->pyMode();
+      pz = ref->pzMode();
+      eta = ref->etaMode();
+      etaError = ref->etaModeError();
+      phi = ref->phiMode();
+      phiError = ref->phiModeError();
+      energy = ref->pMode();
+
       const auto& vec = orig2->Pin();
-      pt = vec.pt();
-      px = vec.px();
-      py = vec.py();
-      pz = vec.pz();
-      eta = vec.eta();
-      phi = vec.phi();
-      energy = vec.energy();
+      eta_ecal = vec.eta();
+      phi_ecal = vec.phi();
 
       const auto& vec2 = orig2->Pout();
-      eta_ecal = vec2.eta();
-      phi_ecal = vec2.phi();
+      eta_hcal = vec2.eta();
+      phi_hcal = vec2.phi();
 
       if (!orig2->GsftrackRefPF().isNull()) {
         charge = orig2->GsftrackRefPF()->charge();
         num_hits = orig2->GsftrackRefPF()->PFRecBrem().size();
       }
 
-      const auto& ref = orig2->GsftrackRef();
+      lambda = ref->lambdaMode();
+      lambdaError = ref->lambdaModeError();
+      theta = ref->thetaMode();
+      thetaError = ref->thetaModeError();
+      vx = ref->vx();
+      vy = ref->vy();
+      vz = ref->vz();
 
       //Find the GSF electron that corresponds to this GSF track
       for (const auto& gsfEle : gsfElectrons) {
@@ -917,9 +994,13 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         pz = ref->position().z();
         energy = ref->energy();
         corr_energy = ref->correctedEnergy();
+        corr_energy_err = ref->correctedEnergyUncertainty();
         layer = ref->layer();
         depth = ref->depth();
         num_hits = ref->recHitFractions().size();
+        vx = ref->vx();
+        vy = ref->vy();
+        vz = ref->vz();
       }
     } else if (type == reco::PFBlockElement::SC) {
       const auto& clref = ((const reco::PFBlockElementSuperCluster*)&orig)->superClusterRef();
@@ -942,20 +1023,27 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         py = clref->position().y();
         pz = clref->position().z();
         energy = clref->energy();
+        corr_energy = clref->preshowerEnergy();
         num_hits = clref->clustersSize();
+        etaError = clref->etaWidth();
+        phiError = clref->phiWidth();
       }
     }
 
     element_pt_.push_back(pt);
+    element_pterror_.push_back(ptError);
     element_px_.push_back(px);
     element_py_.push_back(py);
     element_pz_.push_back(pz);
     element_deltap_.push_back(deltap);
     element_sigmadeltap_.push_back(sigmadeltap);
     element_eta_.push_back(eta);
+    element_etaerror_.push_back(etaError);
     element_phi_.push_back(phi);
+    element_phierror_.push_back(phiError);
     element_energy_.push_back(energy);
     element_corr_energy_.push_back(corr_energy);
+    element_corr_energy_err_.push_back(corr_energy_err);
     element_eta_ecal_.push_back(eta_ecal);
     element_phi_ecal_.push_back(phi_ecal);
     element_eta_hcal_.push_back(eta_hcal);
@@ -976,6 +1064,13 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     element_gsf_electronseed_dnn4_.push_back(gsf_electronseed_dnn4);
     element_gsf_electronseed_dnn5_.push_back(gsf_electronseed_dnn5);
     element_num_hits_.push_back(num_hits);
+    element_lambda_.push_back(lambda);
+    element_lambdaerror_.push_back(lambdaError);
+    element_theta_.push_back(theta);
+    element_thetaerror_.push_back(thetaError);
+    element_vx_.push_back(vx);
+    element_vy_.push_back(vy);
+    element_vz_.push_back(vz);
   } //all_elements
 
   //fill caloparticle_to_element

--- a/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
@@ -143,6 +143,7 @@ private:
   vector<float> trackingparticle_exy_;
   vector<int> trackingparticle_mother_;
   vector<int> trackingparticle_pid_;
+  vector<int> trackingparticle_charge_;
 
   vector<float> simcluster_eta_;
   vector<float> simcluster_phi_;
@@ -166,6 +167,7 @@ private:
   vector<float> caloparticle_bx_;
   vector<float> caloparticle_ev_;
   vector<int> caloparticle_pid_;
+  vector<int> caloparticle_charge_;
   vector<int> caloparticle_idx_trackingparticle_;
 
   vector<float> simhit_frac_;
@@ -310,6 +312,7 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
   t_->Branch("trackingparticle_bx", &trackingparticle_bx_);
   t_->Branch("trackingparticle_ev", &trackingparticle_ev_);
   t_->Branch("trackingparticle_pid", &trackingparticle_pid_);
+  t_->Branch("trackingparticle_charge", &trackingparticle_charge_);
 
   t_->Branch("simcluster_eta", &simcluster_eta_);
   t_->Branch("simcluster_phi", &simcluster_phi_);
@@ -332,6 +335,7 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
   t_->Branch("caloparticle_bx", &caloparticle_bx_);
   t_->Branch("caloparticle_ev", &caloparticle_ev_);
   t_->Branch("caloparticle_pid", &caloparticle_pid_);
+  t_->Branch("caloparticle_charge", &caloparticle_charge_);
   t_->Branch("caloparticle_idx_trackingparticle", &caloparticle_idx_trackingparticle_);
 
   if (saveHits) {
@@ -473,6 +477,7 @@ void PFAnalysis::clearVariables() {
   trackingparticle_exy_.clear();
   trackingparticle_mother_.clear();
   trackingparticle_pid_.clear();
+  trackingparticle_charge_.clear();
 
   simcluster_eta_.clear();
   simcluster_phi_.clear();
@@ -496,6 +501,7 @@ void PFAnalysis::clearVariables() {
   caloparticle_bx_.clear();
   caloparticle_ev_.clear();
   caloparticle_pid_.clear();
+  caloparticle_charge_.clear();
   caloparticle_idx_trackingparticle_.clear();
 
   if (saveHits) {
@@ -756,6 +762,7 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     caloparticle_ev_.push_back(cp.eventId().event());
     caloparticle_bx_.push_back(cp.eventId().bunchCrossing());
     caloparticle_pid_.push_back(cp.pdgId());
+    caloparticle_charge_.push_back(cp.charge());
 
     LOG << "cp=" << ncaloparticle << " pt=" << cp.p4().pt() << " typ=" << cp.pdgId();
 
@@ -1187,6 +1194,7 @@ void PFAnalysis::processTrackingParticles(const edm::View<TrackingParticle>& tra
     trackingparticle_ovz_.push_back(orig_vtx.z());
 
     trackingparticle_pid_.push_back(tp.pdgId());
+    trackingparticle_charge_.push_back(tp.charge());
   }
 }
 

--- a/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
@@ -88,14 +88,14 @@ vector<int> find_element_ref(const vector<ElementWithIndex>& vec, const edm::Ref
         }
       }
     } else if (elem.orig.type() == reco::PFBlockElement::GSF) {
-      const auto& ref = ((const reco::PFBlockElementGsfTrack*)&elem.orig)->clusterRef();
+      const auto& ref = ((const reco::PFBlockElementGsfTrack*)&elem.orig)->GsftrackRef();
       if (ref.isNonnull()) {
         if (ref.key() == r.key()) {
           ret.push_back(i);
         }
       }
     } else if (elem.orig.type() == reco::PFBlockElement::BREM) {
-      const auto& ref = ((const reco::PFBlockElementBrem*)&elem.orig)->clusterRef();
+      const auto& ref = ((const reco::PFBlockElementBrem*)&elem.orig)->GsftrackRef();
       if (ref.isNonnull()) {
         if (ref.key() == r.key()) {
           ret.push_back(i);

--- a/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
@@ -215,6 +215,9 @@ private:
   vector<float> element_px_;
   vector<float> element_py_;
   vector<float> element_pz_;
+  vector<float> element_sigma_x_;
+  vector<float> element_sigma_y_;
+  vector<float> element_sigma_z_;
   vector<float> element_deltap_;
   vector<float> element_sigmadeltap_;
   vector<float> element_eta_;
@@ -251,6 +254,16 @@ private:
   vector<float> element_vx_;
   vector<float> element_vy_;
   vector<float> element_vz_;
+  vector<float> element_time_;
+  vector<float> element_timeerror_;
+  vector<float> element_etaerror1_;
+  vector<float> element_etaerror2_;
+  vector<float> element_etaerror3_;
+  vector<float> element_etaerror4_;
+  vector<float> element_phierror1_;
+  vector<float> element_phierror2_;
+  vector<float> element_phierror3_;
+  vector<float> element_phierror4_;
 
   vector<int> element_distance_i_;
   vector<int> element_distance_j_;
@@ -386,6 +399,9 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
   t_->Branch("element_px", &element_px_);
   t_->Branch("element_py", &element_py_);
   t_->Branch("element_pz", &element_pz_);
+  t_->Branch("element_sigma_x", &element_sigma_x_);
+  t_->Branch("element_sigma_y", &element_sigma_y_);
+  t_->Branch("element_sigma_z", &element_sigma_z_);
   t_->Branch("element_deltap", &element_deltap_);
   t_->Branch("element_sigmadeltap", &element_sigmadeltap_);
   t_->Branch("element_eta", &element_eta_);
@@ -422,6 +438,16 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
   t_->Branch("element_vx", &element_vx_);
   t_->Branch("element_vy", &element_vy_);
   t_->Branch("element_vz", &element_vz_);
+  t_->Branch("element_time", &element_time_);
+  t_->Branch("element_timeerror", &element_timeerror_);
+  t_->Branch("element_etaerror1", &element_etaerror1_);
+  t_->Branch("element_etaerror2", &element_etaerror2_);
+  t_->Branch("element_etaerror3", &element_etaerror3_);
+  t_->Branch("element_etaerror4", &element_etaerror4_);
+  t_->Branch("element_phierror1", &element_phierror1_);
+  t_->Branch("element_phierror2", &element_phierror2_);
+  t_->Branch("element_phierror3", &element_phierror3_);
+  t_->Branch("element_phierror4", &element_phierror4_);
 
   //Distance matrix between PF elements
   t_->Branch("element_distance_i", &element_distance_i_);
@@ -551,6 +577,9 @@ void PFAnalysis::clearVariables() {
   element_px_.clear();
   element_py_.clear();
   element_pz_.clear();
+  element_sigma_x_.clear();
+  element_sigma_y_.clear();
+  element_sigma_z_.clear();
   element_deltap_.clear();
   element_sigmadeltap_.clear();
   element_eta_.clear();
@@ -587,6 +616,16 @@ void PFAnalysis::clearVariables() {
   element_vx_.clear();
   element_vy_.clear();
   element_vz_.clear();
+  element_time_.clear();
+  element_timeerror_.clear();
+  element_etaerror1_.clear();
+  element_etaerror2_.clear();
+  element_etaerror3_.clear();
+  element_etaerror4_.clear();
+  element_phierror1_.clear();
+  element_phierror2_.clear();
+  element_phierror3_.clear();
+  element_phierror4_.clear();
 
   element_distance_i_.clear();
   element_distance_j_.clear();
@@ -851,6 +890,9 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     element_px_.push_back(props.px);
     element_py_.push_back(props.py);
     element_pz_.push_back(props.pz);
+    element_sigma_x_.push_back(props.sigma_x);
+    element_sigma_y_.push_back(props.sigma_y);
+    element_sigma_z_.push_back(props.sigma_z);
     element_deltap_.push_back(props.deltap);
     element_sigmadeltap_.push_back(props.sigmadeltap);
     element_eta_.push_back(props.eta);
@@ -887,6 +929,16 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     element_vx_.push_back(props.vx);
     element_vy_.push_back(props.vy);
     element_vz_.push_back(props.vz);
+    element_time_.push_back(props.time);
+    element_timeerror_.push_back(props.timeerror);
+    element_etaerror1_.push_back(props.etaerror1);
+    element_etaerror2_.push_back(props.etaerror2);
+    element_etaerror3_.push_back(props.etaerror3);
+    element_etaerror4_.push_back(props.etaerror4);
+    element_phierror1_.push_back(props.phierror1);
+    element_phierror2_.push_back(props.phierror2);
+    element_phierror3_.push_back(props.phierror3);
+    element_phierror4_.push_back(props.phierror4);
   }  //all_elements
 
   //fill caloparticle_to_element

--- a/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
@@ -161,6 +161,7 @@ private:
   vector<int> simcluster_pid_;
   vector<int> simcluster_charge_;
   vector<int> simcluster_idx_trackingparticle_;
+  vector<int> simcluster_idx_caloparticle_;
   vector<int> simcluster_nhits_;
   vector<std::map<uint64_t, double>> simcluster_detids_;
 
@@ -348,6 +349,7 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
   t_->Branch("simcluster_pid", &simcluster_pid_);
   t_->Branch("simcluster_charge", &simcluster_charge_);
   t_->Branch("simcluster_idx_trackingparticle", &simcluster_idx_trackingparticle_);
+  t_->Branch("simcluster_idx_caloparticle", &simcluster_idx_caloparticle_);
 
   t_->Branch("caloparticle_eta", &caloparticle_eta_);
   t_->Branch("caloparticle_phi", &caloparticle_phi_);
@@ -507,6 +509,7 @@ void PFAnalysis::clearVariables() {
   simcluster_bx_.clear();
   simcluster_ev_.clear();
   simcluster_idx_trackingparticle_.clear();
+  simcluster_idx_caloparticle_.clear();
 
   caloparticle_pt_.clear();
   caloparticle_eta_.clear();
@@ -819,6 +822,7 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       simcluster_charge_.push_back(simcluster.charge());
       simcluster_bx_.push_back(simcluster.eventId().bunchCrossing());
       simcluster_ev_.push_back(simcluster.eventId().event());
+      simcluster_idx_caloparticle_.push_back(ncaloparticle);
       // std::cout << "  sc pt=" << simcluster.p4().pt() << " typ=" << simcluster.pdgId() << " gen=" << simcluster.genParticles().size() << " tid=" << simcluster.g4Tracks().at(0).trackId() << std::endl;
       
       int simcluster_to_trackingparticle = -1;

--- a/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
@@ -212,7 +212,7 @@ private:
   vector<float> genjet_pt_;
   vector<float> genjet_eta_;
   vector<float> genjet_phi_;
-  vector<float> genjet_mass_;
+  vector<float> genjet_energy_;
 
   vector<float> genmet_pt_;
   vector<float> genmet_phi_;
@@ -375,7 +375,7 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
   t_->Branch("genjet_pt", &genjet_pt_);
   t_->Branch("genjet_eta", &genjet_eta_);
   t_->Branch("genjet_phi", &genjet_phi_);
-  t_->Branch("genjet_mass", &genjet_mass_);
+  t_->Branch("genjet_energy", &genjet_energy_);
 
   t_->Branch("genmet_pt", &genmet_pt_);
   t_->Branch("genmet_phi", &genmet_phi_);
@@ -534,7 +534,7 @@ void PFAnalysis::clearVariables() {
   genjet_pt_.clear();
   genjet_eta_.clear();
   genjet_phi_.clear();
-  genjet_mass_.clear();
+  genjet_energy_.clear();
 
   genmet_pt_.clear();
   genmet_phi_.clear();
@@ -672,7 +672,7 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     genjet_pt_.push_back(genjet.pt());
     genjet_eta_.push_back(genjet.eta());
     genjet_phi_.push_back(genjet.phi());
-    genjet_mass_.push_back(genjet.mass());
+    genjet_energy_.push_back(genjet.energy());
   }
 
   edm::Handle<edm::View<reco::GenMET>> genMETsHandle;

--- a/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
+++ b/Validation/RecoParticleFlow/plugins/PFAnalysisNtuplizer.cc
@@ -144,8 +144,6 @@ private:
   pair<vector<ElementWithIndex>, vector<tuple<int, int, float>>> processBlocks(
       const std::vector<reco::PFBlock>& pfBlocks);
 
-  void associateClusterToSimCluster(const vector<ElementWithIndex>& all_elements);
-
   void clearVariables();
 
   GlobalPoint getHitPosition(const DetId& id);
@@ -198,6 +196,14 @@ private:
   vector<int> simcluster_idx_trackingparticle_;
   vector<int> simcluster_nhits_;
   vector<std::map<uint64_t, double>> simcluster_detids_;
+
+  vector<float> caloparticle_eta_;
+  vector<float> caloparticle_phi_;
+  vector<float> caloparticle_pt_;
+  vector<float> caloparticle_energy_;
+  vector<float> caloparticle_simenergy_;
+  vector<int> caloparticle_pid_;
+  vector<int> caloparticle_idx_trackingparticle_;
 
   vector<float> simhit_frac_;
   vector<float> simhit_x_;
@@ -279,12 +285,9 @@ private:
   vector<int> pfcandidate_pdgid_;
 
   vector<pair<int, int>> trackingparticle_to_element;
-  vector<pair<int, int>> simcluster_to_element;
-  vector<float> simcluster_to_element_cmp;
+  vector<pair<int, int>> caloparticle_to_element;
+  vector<float> caloparticle_to_element_cmp;
   vector<pair<int, int>> element_to_candidate;
-
-  // and also the magnetic field
-  MagneticField const* aField_;
 
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
   edm::ESGetToken<HcalTopology, HcalRecNumberingRecord> topologyToken_;
@@ -293,7 +296,6 @@ private:
 
   CaloGeometry* geom;
   HcalTopology* hcal_topo;
-  const HcalDDDRecConstants* hcons;
 
   bool saveHits;
 };
@@ -353,6 +355,14 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
   t_->Branch("simcluster_idx_trackingparticle", &simcluster_idx_trackingparticle_);
   t_->Branch("simcluster_nhits", &simcluster_nhits_);
 
+  t_->Branch("caloparticle_eta", &caloparticle_eta_);
+  t_->Branch("caloparticle_phi", &caloparticle_phi_);
+  t_->Branch("caloparticle_pt", &caloparticle_pt_);
+  t_->Branch("caloparticle_energy", &caloparticle_energy_);
+  t_->Branch("caloparticle_simenergy", &caloparticle_simenergy_);
+  t_->Branch("caloparticle_pid", &caloparticle_pid_);
+  t_->Branch("caloparticle_idx_trackingparticle", &caloparticle_idx_trackingparticle_);
+
   if (saveHits) {
     t_->Branch("simhit_frac", &simhit_frac_);
     t_->Branch("simhit_x", &simhit_x_);
@@ -380,7 +390,7 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
   t_->Branch("simtrack_x", &simtrack_x_);
   t_->Branch("simtrack_y", &simtrack_y_);
   t_->Branch("simtrack_z", &simtrack_z_);
-  t_->Branch("simtrack_idx_simcluster_", &simtrack_idx_simcluster_);
+  t_->Branch("simtrack_idx_simcluster", &simtrack_idx_simcluster_);
   t_->Branch("simtrack_pid", &simtrack_pid_);
 
   t_->Branch("gen_eta", &gen_eta_);
@@ -438,8 +448,8 @@ PFAnalysis::PFAnalysis(const edm::ParameterSet& iConfig) {
 
   //Links between reco, gen and PFCandidate objects
   t_->Branch("trackingparticle_to_element", &trackingparticle_to_element);
-  t_->Branch("simcluster_to_element", &simcluster_to_element);
-  t_->Branch("simcluster_to_element_cmp", &simcluster_to_element_cmp);
+  t_->Branch("caloparticle_to_element", &caloparticle_to_element);
+  t_->Branch("caloparticle_to_element_cmp", &caloparticle_to_element_cmp);
   t_->Branch("element_to_candidate", &element_to_candidate);
 }  // constructor
 
@@ -451,8 +461,8 @@ void PFAnalysis::clearVariables() {
   ev_event_ = 0;
 
   trackingparticle_to_element.clear();
-  simcluster_to_element.clear();
-  simcluster_to_element_cmp.clear();
+  caloparticle_to_element.clear();
+  caloparticle_to_element_cmp.clear();
   element_to_candidate.clear();
 
   trackingparticle_eta_.clear();
@@ -488,6 +498,14 @@ void PFAnalysis::clearVariables() {
   simcluster_pz_.clear();
   simcluster_idx_trackingparticle_.clear();
   simcluster_nhits_.clear();
+
+  caloparticle_pt_.clear();
+  caloparticle_eta_.clear();
+  caloparticle_phi_.clear();
+  caloparticle_energy_.clear();
+  caloparticle_simenergy_.clear();
+  caloparticle_pid_.clear();
+  caloparticle_idx_trackingparticle_.clear();
 
   if (saveHits) {
     simhit_frac_.clear();
@@ -680,88 +698,76 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   }
 
   processTrackingParticles(trackingParticles, trackingParticlesHandle);
-
-  int idx_simcluster = 0;
-  //Fill genparticles from calorimeter hits
-  for (unsigned long ncaloparticle = 0; ncaloparticle < caloParticles.size(); ncaloparticle++) {
+  
+  map<pair<int, int>, float> caloparticle_to_pfcluster;
+  map<uint64_t, vector<pair<int, float>>> simhit_to_caloparticle;
+  for (unsigned int ncaloparticle = 0; ncaloparticle < caloParticles.size(); ncaloparticle++) {
     const auto& cp = caloParticles.at(ncaloparticle);
     edm::RefToBase<CaloParticle> cpref(caloParticlesHandle, ncaloparticle);
 
-    int nhits = 0;
-    for (const auto& simcluster : cp.simClusters()) {
-      //create a map of detId->energy of all the rechits in all the clusters of this SimCluster
-      map<uint64_t, double> detid_energy;
+    caloparticle_pt_.push_back(cp.p4().pt());
+    caloparticle_eta_.push_back(cp.p4().eta());
+    caloparticle_phi_.push_back(cp.p4().phi());
+    caloparticle_energy_.push_back(cp.p4().energy());
+    caloparticle_simenergy_.push_back(cp.simEnergy());
+    caloparticle_pid_.push_back(cp.pdgId());
 
-      simcluster_nhits_.push_back(nhits);
-      simcluster_eta_.push_back(simcluster->p4().eta());
-      simcluster_phi_.push_back(simcluster->p4().phi());
-      simcluster_pt_.push_back(simcluster->p4().pt());
-      simcluster_energy_.push_back(simcluster->energy());
-      simcluster_pid_.push_back(simcluster->pdgId());
-      simcluster_bx_.push_back(simcluster->eventId().bunchCrossing());
-      simcluster_ev_.push_back(simcluster->eventId().event());
+    const auto& simtrack = cp.g4Tracks().at(0);
 
-      simcluster_px_.push_back(simcluster->p4().x());
-      simcluster_py_.push_back(simcluster->p4().y());
-      simcluster_pz_.push_back(simcluster->p4().z());
-
-      for (const auto& hf : simcluster->hits_and_fractions()) {
-        DetId id(hf.first);
-
-        if (id.det() == DetId::Hcal || id.det() == DetId::Ecal) {
-          const auto& pos = getHitPosition(id);
-          nhits += 1;
-
-          const float x = pos.x();
-          const float y = pos.y();
-          const float z = pos.z();
-          const float eta = pos.eta();
-          const float phi = pos.phi();
-
-          simhit_frac_.push_back(hf.second);
-          simhit_x_.push_back(x);
-          simhit_y_.push_back(y);
-          simhit_z_.push_back(z);
-          simhit_det_.push_back(id.det());
-          simhit_subdet_.push_back(id.subdetId());
-          simhit_eta_.push_back(eta);
-          simhit_phi_.push_back(phi);
-          simhit_idx_simcluster_.push_back(idx_simcluster);
-          simhit_detid_.push_back(id.rawId());
-          detid_energy[id.rawId()] += hf.second;
-        }
+    int caloparticle_to_trackingparticle = -1;
+    for (size_t itp = 0; itp < trackingParticles.size(); itp++) {
+      const auto& simtrack2 = trackingParticles.at(itp).g4Tracks().at(0);
+      //compare the two tracks, taking into account that both eventId and trackId need to be compared due to pileup
+      if (simtrack.eventId() == simtrack2.eventId() && simtrack.trackId() == simtrack2.trackId()) {
+        caloparticle_to_trackingparticle = itp;
+        //we are satisfied with the first match, in practice there should not be more
+        break;
       }
+    }  //trackingParticles
+    caloparticle_idx_trackingparticle_.push_back(caloparticle_to_trackingparticle);
+      
 
-      int simcluster_to_trackingparticle = -1;
-      for (const auto& simtrack : simcluster->g4Tracks()) {
-        simtrack_x_.push_back(simtrack.trackerSurfacePosition().x());
-        simtrack_y_.push_back(simtrack.trackerSurfacePosition().y());
-        simtrack_z_.push_back(simtrack.trackerSurfacePosition().z());
-        simtrack_idx_simcluster_.push_back(idx_simcluster);
-        simtrack_pid_.push_back(simtrack.type());
-
-        for (unsigned int itp = 0; itp < trackingParticles.size(); itp++) {
-          const auto& simtrack2 = trackingParticles.at(itp).g4Tracks().at(0);
-          //compare the two tracks, taking into account that both eventId and trackId need to be compared due to pileup
-          if (simtrack.eventId() == simtrack2.eventId() && simtrack.trackId() == simtrack2.trackId()) {
-            simcluster_to_trackingparticle = itp;
-            //we are satisfied with the first match, in practice there should not be more
-            break;
-          }
-        }  //trackingParticles
-      }  //simcluster tracks
-
-      simcluster_detids_.push_back(detid_energy);
-      simcluster_idx_trackingparticle_.push_back(simcluster_to_trackingparticle);
-
-      idx_simcluster += 1;
+    for (const auto& simcluster : cp.simClusters()) {
+      for (const auto& hf : simcluster->hits_and_fractions()) {
+        simhit_to_caloparticle[hf.first].push_back({ncaloparticle, hf.second});
+      }
     }  //simclusters
-  }  //caloParticles
+  } //caloParticles
 
-  associateClusterToSimCluster(all_elements);
+  
+  //fill pfcluster to rechit
+  map<int, vector<pair<uint64_t, float>>> pfcluster_to_rechit;
+  for (size_t ielem = 0; ielem < all_elements.size(); ielem++) {
+    const auto& elem = all_elements[ielem];
+    const auto& type = elem.orig.type();
+    if (type == reco::PFBlockElement::ECAL || type == reco::PFBlockElement::HCAL || type == reco::PFBlockElement::PS1 ||
+        type == reco::PFBlockElement::PS2 || type == reco::PFBlockElement::HO || type == reco::PFBlockElement::HFHAD ||
+        type == reco::PFBlockElement::HFEM) {
+      const auto& clref = elem.orig.clusterRef();
+      assert(clref.isNonnull());
+      const auto& cluster = *clref;
+
+      //all rechits and the energy fractions in this cluster
+      const vector<reco::PFRecHitFraction>& rechit_fracs = cluster.recHitFractions();
+      for (const auto& rh : rechit_fracs) {
+        const reco::PFRecHit pfrh = *rh.recHitRef();
+        pfcluster_to_rechit[ielem].push_back({pfrh.detId(), pfrh.energy()*rh.fraction()});
+      }  //rechit_fracs
+    } else if (type == reco::PFBlockElement::SC) {
+      const auto& clref = ((const reco::PFBlockElementSuperCluster*)&(elem.orig))->superClusterRef();
+      assert(clref.isNonnull());
+      const auto& cluster = *clref;
+
+      //all rechits and the energy fractions in this cluster
+      const auto& rechit_fracs = cluster.hitsAndFractions();
+      for (const auto& rh : rechit_fracs) {
+        pfcluster_to_rechit[ielem].push_back({rh.first.rawId(), rh.second});
+      }  //rechit_fracs
+    }
+  } //all_elements
 
   //fill elements
-  for (unsigned int ielem = 0; ielem < all_elements.size(); ielem++) {
+  for (size_t ielem = 0; ielem < all_elements.size(); ielem++) {
     const auto& elem = all_elements.at(ielem);
     const auto& orig = elem.orig;
     reco::PFBlockElement::Type type = orig.type();
@@ -895,6 +901,22 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
                type == reco::PFBlockElement::HO || type == reco::PFBlockElement::HFHAD ||
                type == reco::PFBlockElement::HFEM) {
       const auto& ref = ((const reco::PFBlockElementCluster*)&orig)->clusterRef();
+      const auto& found = pfcluster_to_rechit.find(ielem);
+      if (found != pfcluster_to_rechit.end()) {
+        for (const auto& rechit_frac : (*found).second) {
+          const auto& found_cp = simhit_to_caloparticle.find(rechit_frac.first);
+          if (found_cp != simhit_to_caloparticle.end()) {
+            for (const auto& simhit_frac : (*found_cp).second) {
+              //(icalo, ielem) += rechit_energy*rechit_fraction*simhit_fraction
+              const pair<size_t, size_t> key{simhit_frac.first, ielem};
+              if (caloparticle_to_pfcluster.find(key) == caloparticle_to_pfcluster.end()) {
+                caloparticle_to_pfcluster[key] = 0.0;
+              }
+              caloparticle_to_pfcluster[key] += rechit_frac.second*simhit_frac.second;
+            }
+          } 
+        } 
+      }
       if (ref.isNonnull()) {
         cluster_flags = ref->flags();
         eta = ref->eta();
@@ -920,18 +942,6 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
         pz = clref->position().z();
         energy = clref->energy();
         num_hits = clref->clustersSize();
-      }
-    }
-    vector<int> tps;
-    for (const auto& t : trackingparticle_to_element) {
-      if (t.second == (int)ielem) {
-        tps.push_back(t.first);
-      }
-    }
-    vector<int> scs;
-    for (const auto& t : simcluster_to_element) {
-      if (t.second == (int)ielem) {
-        scs.push_back(t.first);
       }
     }
 
@@ -960,6 +970,14 @@ void PFAnalysis::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     element_cluster_flags_.push_back(cluster_flags);
     element_gsf_electronseed_trkorecal_.push_back(gsf_electronseed_trkorecal);
     element_num_hits_.push_back(num_hits);
+  } //all_elements
+
+  //fill caloparticle_to_element
+  for (const auto& cp_to_pf : caloparticle_to_pfcluster) {
+    const auto& cp_pf = cp_to_pf.first;
+    const auto energy = cp_to_pf.second;
+    caloparticle_to_element.push_back(cp_pf);
+    caloparticle_to_element_cmp.push_back(energy);
   }
 
   //associate candidates to elements
@@ -1078,122 +1096,7 @@ pair<vector<ElementWithIndex>, vector<tuple<int, int, float>>> PFAnalysis::proce
 
 }  //processBlocks
 
-void PFAnalysis::associateClusterToSimCluster(const vector<ElementWithIndex>& all_elements) {
-  vector<map<uint64_t, double>> detids_elements;
-  map<uint64_t, double> rechits_energy_all;
-
-  int idx_element = 0;
-  for (const auto& elem : all_elements) {
-    map<uint64_t, double> detids;
-    const auto& type = elem.orig.type();
-
-    if (type == reco::PFBlockElement::ECAL || type == reco::PFBlockElement::HCAL || type == reco::PFBlockElement::PS1 ||
-        type == reco::PFBlockElement::PS2 || type == reco::PFBlockElement::HO || type == reco::PFBlockElement::HFHAD ||
-        type == reco::PFBlockElement::HFEM) {
-      const auto& clref = elem.orig.clusterRef();
-      assert(clref.isNonnull());
-      const auto& cluster = *clref;
-
-      //all rechits and the energy fractions in this cluster
-      const vector<reco::PFRecHitFraction>& rechit_fracs = cluster.recHitFractions();
-      for (const auto& rh : rechit_fracs) {
-        const reco::PFRecHit pfrh = *rh.recHitRef();
-        if (detids.find(pfrh.detId()) != detids.end()) {
-          continue;
-        }
-        detids[pfrh.detId()] += pfrh.energy() * rh.fraction();
-        const auto id = DetId(pfrh.detId());
-        float x = 0;
-        float y = 0;
-        float z = 0;
-        float eta = 0;
-        float phi = 0;
-
-        const auto& pos = getHitPosition(id);
-        x = pos.x();
-        y = pos.y();
-        z = pos.z();
-        eta = pos.eta();
-        phi = pos.phi();
-
-        rechit_x_.push_back(x);
-        rechit_y_.push_back(y);
-        rechit_z_.push_back(z);
-        rechit_det_.push_back(id.det());
-        rechit_subdet_.push_back(id.subdetId());
-        rechit_eta_.push_back(eta);
-        rechit_phi_.push_back(phi);
-        rechit_e_.push_back(pfrh.energy() * rh.fraction());
-        rechit_idx_element_.push_back(idx_element);
-        rechit_detid_.push_back(id.rawId());
-        rechits_energy_all[id.rawId()] += pfrh.energy() * rh.fraction();
-      }  //rechit_fracs
-    } else if (type == reco::PFBlockElement::SC) {
-      const auto& clref = ((const reco::PFBlockElementSuperCluster*)&(elem.orig))->superClusterRef();
-      assert(clref.isNonnull());
-      const auto& cluster = *clref;
-
-      //all rechits and the energy fractions in this cluster
-      const auto& rechit_fracs = cluster.hitsAndFractions();
-      for (const auto& rh : rechit_fracs) {
-        if (detids.find(rh.first.rawId()) != detids.end()) {
-          continue;
-        }
-        detids[rh.first.rawId()] += cluster.energy() * rh.second;
-        const auto id = rh.first;
-        float x = 0;
-        float y = 0;
-        float z = 0;
-        float eta = 0;
-        float phi = 0;
-
-        const auto& pos = getHitPosition(id);
-        x = pos.x();
-        y = pos.y();
-        z = pos.z();
-        eta = pos.eta();
-        phi = pos.phi();
-
-        rechit_x_.push_back(x);
-        rechit_y_.push_back(y);
-        rechit_z_.push_back(z);
-        rechit_det_.push_back(id.det());
-        rechit_subdet_.push_back(id.subdetId());
-        rechit_eta_.push_back(eta);
-        rechit_phi_.push_back(phi);
-        rechit_e_.push_back(rh.second);
-        rechit_idx_element_.push_back(idx_element);
-        rechit_detid_.push_back(id.rawId());
-        rechits_energy_all[id.rawId()] += cluster.energy() * rh.second;
-      }  //rechit_fracs
-    }
-    detids_elements.push_back(detids);
-    idx_element += 1;
-  }  //all_elements
-
-  //associate elements (reco clusters) to simclusters
-  int ielement = 0;
-  for (const auto& detids : detids_elements) {
-    int isimcluster = 0;
-    if (!detids.empty()) {
-      for (const auto& simcluster_detids : simcluster_detids_) {
-        //get the energy of the simcluster hits that matches detids of the rechits
-        double cmp = detid_compare(detids, simcluster_detids);
-        if (cmp > 0) {
-          simcluster_to_element.push_back(make_pair(isimcluster, ielement));
-          simcluster_to_element_cmp.push_back((float)cmp);
-        }
-        isimcluster += 1;
-      }
-    }  //element had rechits
-    ielement += 1;
-  }  //rechit clusters
-}
-
-void PFAnalysis::beginRun(edm::Run const& iEvent, edm::EventSetup const& es) {
-  hcons = &es.getData(hcalDDDrecToken_);
-  aField_ = &es.getData(magFieldToken_);
-}
+void PFAnalysis::beginRun(edm::Run const& iEvent, edm::EventSetup const& es) {}
 
 void PFAnalysis::endRun(edm::Run const& iEvent, edm::EventSetup const&) {}
 

--- a/Validation/RecoParticleFlow/python/customize_pfanalysis.py
+++ b/Validation/RecoParticleFlow/python/customize_pfanalysis.py
@@ -81,4 +81,9 @@ def customize_step3(process):
     
     process.schedule.append(process.pfana_path)
 
+    # process.load("FWCore.MessageService.MessageLogger_cfi")
+    # process.MessageLogger.cerr.threshold = "TRACE"
+    # process.MessageLogger.debugModules = ["*"]
+
+
     return process

--- a/Validation/RecoParticleFlow/python/customize_pfanalysis.py
+++ b/Validation/RecoParticleFlow/python/customize_pfanalysis.py
@@ -31,10 +31,9 @@ def customize_step2(process):
         )
     )
     process.caloParticles.doHGCAL = False
-    process.caloParticles.allowDifferentSimHitProcesses = True
     process.mix.digitizers.caloParticles = process.caloParticles
     process.mix.digitizers.mergedtruth.ignoreTracksOutsideVolume = True
-    process.mix.digitizers.mergedtruth.allowDifferentSimHitProcesses = True
+    process.mix.digitizers.mergedtruth.allowDifferentSimHitProcesses = False
     process.mix.digitizers.mergedtruth.select.signalOnlyTP = False
 
     process.FEVTDEBUGHLToutput.outputCommands.append('keep *_simSiStripDigis_*_*')

--- a/Validation/RecoParticleFlow/python/customize_pfanalysis.py
+++ b/Validation/RecoParticleFlow/python/customize_pfanalysis.py
@@ -49,6 +49,7 @@ def customize_step3(process):
     process.FEVTDEBUGHLToutput.outputCommands.append('keep *_*_MergedTrackTruth_*')
     process.FEVTDEBUGHLToutput.outputCommands.append('keep recoPFRecTracks_*_*_*')
     process.FEVTDEBUGHLToutput.outputCommands.append('keep recoPFRecHits_*_*_*')
+    process.FEVTDEBUGHLToutput.outputCommands.append('keep recoPFRecHitFractions_*_*_*')
     process.FEVTDEBUGHLToutput.outputCommands.append('keep recoGsfPFRecTracks_*_*_*')
     process.FEVTDEBUGHLToutput.outputCommands.append('keep *_particleFlowBlock_*_*')
     process.FEVTDEBUGHLToutput.outputCommands.append('keep recoTracks_standAloneMuons_*_*')

--- a/Validation/RecoParticleFlow/python/customize_pfanalysis.py
+++ b/Validation/RecoParticleFlow/python/customize_pfanalysis.py
@@ -59,4 +59,26 @@ def customize_step3(process):
     process.FEVTDEBUGHLToutput.outputCommands.append('keep recoGsfTracks_*_*_*')
     process.FEVTDEBUGHLToutput.outputCommands.append('keep recoPFBlocks_*_*_*')
 
+    process.load("SimTracker.TrackerHitAssociation.tpClusterProducer_cfi")
+    process.load("SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi")
+    process.load("SimTracker.TrackAssociatorProducers.trackAssociatorByHits_cfi")
+    process.load("SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi")
+      
+    process.trackingParticleGsfTrackAssociation = process.trackingParticleRecoTrackAsssociation.clone(label_tr="electronGsfTracks")
+    
+    process.pfana = cms.EDAnalyzer('PFAnalysis')
+    
+    process.TFileService = cms.Service("TFileService",
+        fileName = cms.string("pfntuple.root")
+    )
+    
+    process.pfana_path = cms.Path(
+      process.tpClusterProducer*
+      process.quickTrackAssociatorByHits*
+      process.trackingParticleRecoTrackAsssociation*
+      process.trackingParticleGsfTrackAssociation*
+      process.pfana)
+    
+    process.schedule.append(process.pfana_path)
+
     return process

--- a/Validation/RecoParticleFlow/python/customize_pfanalysis.py
+++ b/Validation/RecoParticleFlow/python/customize_pfanalysis.py
@@ -40,6 +40,9 @@ def customize_step2(process):
     process.FEVTDEBUGHLToutput.outputCommands.append('keep *_simSiPixelDigis_*_*')
     process.FEVTDEBUGHLToutput.outputCommands.append('keep *_*_MergedCaloTruth_*')
     process.FEVTDEBUGHLToutput.outputCommands.append('keep *_*_MergedTrackTruth_*')
+    #process.FEVTDEBUGHLToutput.outputCommands.append("keep *_*G4*_*_*")
+    #process.FEVTDEBUGHLToutput.outputCommands.append("keep SimClustersedmAssociation_mix_*_*")
+    #process.FEVTDEBUGHLToutput.outputCommands.append("keep CaloParticlesedmAssociation_mix_*_*")
     return process
  
 def customize_step3(process):
@@ -58,6 +61,9 @@ def customize_step3(process):
     process.FEVTDEBUGHLToutput.outputCommands.append('keep recoTracks_*_*_*')
     process.FEVTDEBUGHLToutput.outputCommands.append('keep recoGsfTracks_*_*_*')
     process.FEVTDEBUGHLToutput.outputCommands.append('keep recoPFBlocks_*_*_*')
+    #process.FEVTDEBUGHLToutput.outputCommands.append("keep *_*G4*_*_*")
+    #process.FEVTDEBUGHLToutput.outputCommands.append("keep SimClustersedmAssociation_mix_*_*")
+    #process.FEVTDEBUGHLToutput.outputCommands.append("keep CaloParticlesedmAssociation_mix_*_*")
 
     process.load("SimTracker.TrackerHitAssociation.tpClusterProducer_cfi")
     process.load("SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi")

--- a/Validation/RecoParticleFlow/test/pfanalysis_ntuple.py
+++ b/Validation/RecoParticleFlow/test/pfanalysis_ntuple.py
@@ -34,7 +34,7 @@ process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck")
 )
 
-process.ana = cms.EDAnalyzer('PFAnalysis')
+process.pfana = cms.EDAnalyzer('PFAnalysis')
 
 process.TFileService = cms.Service("TFileService",
     fileName = cms.string("pfntuple.root")
@@ -44,4 +44,11 @@ process.p = cms.Path(
   process.quickTrackAssociatorByHits*
   process.trackingParticleRecoTrackAsssociation*
   process.trackingParticleGsfTrackAssociation*
-  process.ana)
+  process.pfana)
+
+
+#Enable LogTrace in PFAnalysisNtuplizer
+## scram b -j8 USER_CXXFLAGS="-DEDM_ML_DEBUG"
+#process.MessageLogger.cerr.threshold = "DEBUG"
+#process.MessageLogger.debugModules = ["pfana"]
+

--- a/Validation/RecoParticleFlow/test/pfanalysis_ntuple.py
+++ b/Validation/RecoParticleFlow/test/pfanalysis_ntuple.py
@@ -18,6 +18,8 @@ process.load("SimTracker.TrackerHitAssociation.tpClusterProducer_cfi")
 process.load("SimTracker.TrackAssociatorProducers.quickTrackAssociatorByHits_cfi")
 process.load("SimTracker.TrackAssociatorProducers.trackAssociatorByHits_cfi")
 process.load("SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi")
+  
+process.trackingParticleGsfTrackAssociation = process.trackingParticleRecoTrackAsssociation.clone(label_tr="electronGsfTracks")
 
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, "auto:phase1_2022_realistic")
@@ -41,4 +43,5 @@ process.p = cms.Path(
   process.tpClusterProducer*
   process.quickTrackAssociatorByHits*
   process.trackingParticleRecoTrackAsssociation*
+  process.trackingParticleGsfTrackAssociation*
   process.ana)

--- a/Validation/RecoParticleFlow/test/run_relval.sh
+++ b/Validation/RecoParticleFlow/test/run_relval.sh
@@ -113,7 +113,7 @@ if [ $STEP == "RECO" ]; then
 	FILENAME=`sed -n "${NJOB}p" $INPUT_FILELIST`
 	echo "FILENAME="$FILENAME
 
-	cmsDriver.py step3 --conditions $CONDITIONS -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT --datatier MINIAODSIM --nThreads $NTHREADS -n 100 --era $ERA --eventcontent MINIAODSIM --geometry=$GEOM --filein step2.root --fileout file:step3_inMINIAODSIM.root --no_exec --python_filename=step3.py $CUSTOM
+	cmsDriver.py step3 --conditions $CONDITIONS -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT --datatier MINIAODSIM --nThreads $NTHREADS -n -1 --era $ERA --eventcontent MINIAODSIM --geometry=$GEOM --filein step2.root --fileout file:step3_inMINIAODSIM.root --no_exec --python_filename=step3.py $CUSTOM
 	
     else
 	
@@ -132,7 +132,7 @@ if [ $STEP == "RECO" ]; then
 	echo "FILENAME="$FILENAME
 	#Run the actual CMS reco with particle flow.
 	echo "Running step RECO" 
-	cmsDriver.py step3 --conditions $CONDITIONS -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT --datatier MINIAODSIM --nThreads $NTHREADS -n 100 --era $ERA --eventcontent MINIAODSIM --geometry=$GEOM --filein $FILENAME --fileout file:step3_inMINIAODSIM.root $CUSTOM | tee step3.log  2>&1
+	cmsDriver.py step3 --conditions $CONDITIONS -s RAW2DIGI,L1Reco,RECO,RECOSIM,PAT --datatier MINIAODSIM --nThreads $NTHREADS -n -1 --era $ERA --eventcontent MINIAODSIM --geometry=$GEOM --filein $FILENAME --fileout file:step3_inMINIAODSIM.root $CUSTOM | tee step3.log  2>&1
    
 	#NanoAOD
 	#On lxplus, this step takes about 1 minute / 1000 events


### PR DESCRIPTION
Keep track of the updates from 2022 -> 2025 on top of CMSSW_15_0_1.
Done by cherry picking the changes on top of `from-CMSSW_15_0_1`.

We found that the combination of CUDA, cudnn and onnxruntime in CMSSW_14_2_2 used in https://github.com/jpata/cmssw/pull/68 did not give correct results in CMSSW inference on GPU using the fused model.

It works correctly with this branch on top of CMSSW_15_0_1.