### PR TITLE
enable pid, eta, pt dependent mlpf-pu cut

### DIFF
--- a/CommonTools/PileupAlgos/plugins/BuildFile.xml
+++ b/CommonTools/PileupAlgos/plugins/BuildFile.xml
@@ -8,4 +8,5 @@
   <use name="CommonTools/PileupAlgos"/>
   <use name="fastjet"/>
   <use name="fastjet-contrib"/>
+  <use name="correctionlib"/>
 </library>

--- a/CommonTools/PileupAlgos/plugins/MLPFPUProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/MLPFPUProducer.cc
@@ -65,6 +65,7 @@ private:
   double fDZCut;
   double fEtaMinUseDZ;
   double fPtMaxCharged;
+  double fPtMaxNeutrals;
   double fEtaMaxCharged;
   double fPtMaxPhotons;
   double fEtaMaxPhotons;
@@ -77,7 +78,8 @@ private:
   int fVtxNdofCut;
   double fVtxZCut;
   double fMLPFPUCut;
-  edm::FileInPath fPUthres;
+  edm::FileInPath fPUThresFile;
+  std::string fPUThresSet;
   bool fapplyCHS;
   bool fapplyMLPF;
 
@@ -94,6 +96,7 @@ MLPFPUProducer::MLPFPUProducer(const edm::ParameterSet& iConfig) {
   fEtaMinUseDZ = iConfig.getParameter<double>("EtaMinUseDeltaZ");
   fPtMaxCharged = iConfig.getParameter<double>("PtMaxCharged");
   fEtaMaxCharged = iConfig.getParameter<double>("EtaMaxCharged");
+  fPtMaxNeutrals = iConfig.getParameter<double>("PtMaxNeutrals");
   fPtMaxPhotons = iConfig.getParameter<double>("PtMaxPhotons");
   fEtaMaxPhotons = iConfig.getParameter<double>("EtaMaxPhotons");
   fPtMinForFromPV2Recovery = iConfig.getParameter<double>("PtMinForFromPV2Recovery");
@@ -105,7 +108,8 @@ MLPFPUProducer::MLPFPUProducer(const edm::ParameterSet& iConfig) {
   fVtxNdofCut = iConfig.getParameter<int>("vtxNdofCut");
   fVtxZCut = iConfig.getParameter<double>("vtxZCut");
   fMLPFPUCut = iConfig.getParameter<double>("mlpfPUCut");
-  fPUthres = iConfig.getParameter<edm::FileInPath>("PUthres");
+  fPUThresFile = iConfig.getParameter<edm::FileInPath>("PUThresFile");
+  fPUThresSet = iConfig.getParameter<std::string>("PUThresSet");
   fapplyCHS = iConfig.getParameter<bool>("applyCHS");
   fapplyMLPF = iConfig.getParameter<bool>("applyMLPF");
 
@@ -275,10 +279,12 @@ void MLPFPUProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
         }
         // if neutral, use MLPF prediction
         if ((std::abs(pReco.charge) == 0) && fapplyMLPF) {
-              auto cset = correction::CorrectionSet::from_file(fPUthres.fullPath());
-              auto corr = cset->at("80TPR");
+              auto cset = correction::CorrectionSet::from_file(fPUThresFile.fullPath());
+              auto corr = cset->at(fPUThresSet);
 	      float threshold = corr->evaluate({std::abs(pReco.eta), pReco.pdgId, pReco.pt});
-	      pReco.id = pPF->mlpf_pu() < threshold ? 1:2; //applying a pdgid, pt, eta dependent threshold instead of a single fMLPFPUCut
+	      //applying a pdgid, pt, eta dependent threshold instead of a single fMLPFPUCut
+	      //we keep any neutrals with pt > fPtMaxNeutrals
+	      pReco.id = ((pPF->mlpf_pu() < threshold) | (pReco.pt > fPtMaxNeutrals)) ? 1:2;
 	}
       } else if (lPack->vertexRef().isNonnull()) {
         pDZ = lPack->dz();
@@ -476,7 +482,7 @@ void MLPFPUProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<double>("EtaMaxCharged", 99999.);
   desc.add<double>("PtMaxPhotons", -1.);
   desc.add<double>("EtaMaxPhotons", 2.5);
-  desc.add<double>("PtMaxNeutrals", 200.);
+  desc.add<double>("PtMaxNeutrals", 15.);
   desc.add<double>("PtMaxNeutralsStartSlope", 0.);
   desc.add<double>("PtMinForFromPV2Recovery", 0.);
   desc.add<uint>("NumOfPUVtxsForCharged", 0);
@@ -498,7 +504,8 @@ void MLPFPUProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<double>("MinPuppiWeight", .01);
   desc.add<bool>("usePUProxyValue", false);
   desc.add<double>("mlpfPUCut", 0.5);
-  desc.add<edm::FileInPath>("PUthres", edm::FileInPath("RecoParticleFlow/PFProducer/data/mlpf/mlpfpu_threshold_80TPR.json"));
+  desc.add<edm::FileInPath>("PUThresFile", edm::FileInPath("RecoParticleFlow/PFProducer/data/mlpf/mlpfpu_threshold_80TPR.json"));
+  desc.add<std::string>("PUThresSet", "80TPR");
   desc.add<edm::InputTag>("PUProxyValue", edm::InputTag(""));
   descriptions.add("MLPFPUProducer", desc);
 }

--- a/CommonTools/PileupAlgos/plugins/MLPFPUProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/MLPFPUProducer.cc
@@ -18,6 +18,9 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "correction.h"
+
 #include <memory>
 
 // ------------------------------------------------------------------------------------------
@@ -74,6 +77,7 @@ private:
   int fVtxNdofCut;
   double fVtxZCut;
   double fMLPFPUCut;
+  edm::FileInPath fPUthres;
   bool fapplyCHS;
   bool fapplyMLPF;
 
@@ -101,6 +105,7 @@ MLPFPUProducer::MLPFPUProducer(const edm::ParameterSet& iConfig) {
   fVtxNdofCut = iConfig.getParameter<int>("vtxNdofCut");
   fVtxZCut = iConfig.getParameter<double>("vtxZCut");
   fMLPFPUCut = iConfig.getParameter<double>("mlpfPUCut");
+  fPUthres = iConfig.getParameter<edm::FileInPath>("PUthres");
   fapplyCHS = iConfig.getParameter<bool>("applyCHS");
   fapplyMLPF = iConfig.getParameter<bool>("applyMLPF");
 
@@ -268,9 +273,12 @@ void MLPFPUProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) 
               pReco.id = 1;
           }
         }
-        // if undecided by CHS, use MLPF prediction
-        if (pReco.id==0 && fapplyMLPF) {
-	      pReco.id = pPF->mlpf_pu() < fMLPFPUCut? 1:2;
+        // if neutral, use MLPF prediction
+        if ((std::abs(pReco.charge) == 0) && fapplyMLPF) {
+              auto cset = correction::CorrectionSet::from_file(fPUthres.fullPath());
+              auto corr = cset->at("80TPR");
+	      float threshold = corr->evaluate({std::abs(pReco.eta), pReco.pdgId, pReco.pt});
+	      pReco.id = pPF->mlpf_pu() < threshold ? 1:2; //applying a pdgid, pt, eta dependent threshold instead of a single fMLPFPUCut
 	}
       } else if (lPack->vertexRef().isNonnull()) {
         pDZ = lPack->dz();
@@ -490,6 +498,7 @@ void MLPFPUProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<double>("MinPuppiWeight", .01);
   desc.add<bool>("usePUProxyValue", false);
   desc.add<double>("mlpfPUCut", 0.5);
+  desc.add<edm::FileInPath>("PUthres", edm::FileInPath("RecoParticleFlow/PFProducer/data/mlpf/mlpfpu_threshold_80TPR.json"));
   desc.add<edm::InputTag>("PUProxyValue", edm::InputTag(""));
   descriptions.add("MLPFPUProducer", desc);
 }

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -80,11 +80,12 @@ mlpfpu = MLPFPUProducer.clone(
                       PtMaxCharged = primaryVertexAssociationJME.assignment.PtMaxCharged,
                       NumOfPUVtxsForCharged = primaryVertexAssociationJME.assignment.NumOfPUVtxsForCharged,
                       DeltaZCutForChargedFromPUVtxs = primaryVertexAssociationJME.assignment.DzCutForChargedFromPUVtxs,
-                      PtMaxPhotons = 20.,
+                      PtMaxNeutrals = 15,
                       UseFromPV2Recovery = True,
                       PtMinForFromPV2Recovery = 4.,
                       clonePackedCands   = False, # should only be set to True for MiniAOD
-                      PUthres = "RecoParticleFlow/PFProducer/data/mlpf/mlpfpu_threshold_80TPR.json",
+                      PUThresFile = "RecoParticleFlow/PFProducer/data/mlpf/mlpfpu_threshold_80TPR.json",
+                      PUThresSet = "80TPR",
                       applyCHS = True,
                       applyMLPF = True
 )

--- a/CommonTools/PileupAlgos/python/Puppi_cff.py
+++ b/CommonTools/PileupAlgos/python/Puppi_cff.py
@@ -73,22 +73,22 @@ puppi.algos.append(cms.PSet(
 
 from Configuration.ProcessModifiers.mlpf_cff import mlpf
 from CommonTools.PileupAlgos.MLPFPUProducer_cfi import MLPFPUProducer
-#mlpfpu = MLPFPUProducer.clone(
-#                      UseDeltaZCutForPileup = False,
-#                      DeltaZCut = primaryVertexAssociationJME.assignment.maxDzForPrimaryAssignment,
-#                      EtaMinUseDeltaZ = primaryVertexAssociationJME.assignment.EtaMinUseDz,
-#                      PtMaxCharged = primaryVertexAssociationJME.assignment.PtMaxCharged,
-#                      NumOfPUVtxsForCharged = primaryVertexAssociationJME.assignment.NumOfPUVtxsForCharged,
-#                      DeltaZCutForChargedFromPUVtxs = primaryVertexAssociationJME.assignment.DzCutForChargedFromPUVtxs,
-#                      PtMaxPhotons = 20.,
-#                      UseFromPV2Recovery = True,
-#                      PtMinForFromPV2Recovery = 4.,
-#                      clonePackedCands   = False, # should only be set to True for MiniAOD
-#                      mlpfPUCut = 0.6,
-#                      applyCHS = True,
-#                      applyMLPF = False
-#)
-#mlpf.toReplaceWith(puppi, mlpfpu)
+mlpfpu = MLPFPUProducer.clone(
+                      UseDeltaZCutForPileup = False,
+                      DeltaZCut = primaryVertexAssociationJME.assignment.maxDzForPrimaryAssignment,
+                      EtaMinUseDeltaZ = primaryVertexAssociationJME.assignment.EtaMinUseDz,
+                      PtMaxCharged = primaryVertexAssociationJME.assignment.PtMaxCharged,
+                      NumOfPUVtxsForCharged = primaryVertexAssociationJME.assignment.NumOfPUVtxsForCharged,
+                      DeltaZCutForChargedFromPUVtxs = primaryVertexAssociationJME.assignment.DzCutForChargedFromPUVtxs,
+                      PtMaxPhotons = 20.,
+                      UseFromPV2Recovery = True,
+                      PtMinForFromPV2Recovery = 4.,
+                      clonePackedCands   = False, # should only be set to True for MiniAOD
+                      PUthres = "RecoParticleFlow/PFProducer/data/mlpf/mlpfpu_threshold_80TPR.json",
+                      applyCHS = True,
+                      applyMLPF = True
+)
+mlpf.toReplaceWith(puppi, mlpfpu)
 
 from Configuration.Eras.Modifier_phase2_common_cff import phase2_common
 phase2_common.toModify(


### PR DESCRIPTION
This PR enables pid, eta, pt dependent mlpf-pu cut to reject pileup particles.

Previous version only allow a single `mlpfPUCut` cut for all particles in `CommonTools/PileupAlgos/plugins/MLPFPUProducer.cc`. 

Now user can pass a correctionlib json file following schema v2 using the `PUthres` parameter in `CommonTools/PileupAlgos/python/Puppi_cff.py` to apply a calibrated cut, dependent on pid, eta, and pt. The cut will be applied to neutral hadrons, gamma, and HF particles.